### PR TITLE
Added Embeds Support

### DIFF
--- a/DiscordChatExporter.Core/DiscordChatExporter.Core.csproj
+++ b/DiscordChatExporter.Core/DiscordChatExporter.Core.csproj
@@ -6,8 +6,13 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <None Remove="Resources\ExportService\Shared.css" />
+    </ItemGroup>
+
+    <ItemGroup>
         <EmbeddedResource Include="Resources\ExportService\DarkTheme.css" />
         <EmbeddedResource Include="Resources\ExportService\LightTheme.css" />
+        <EmbeddedResource Include="Resources\ExportService\Shared.css" />
     </ItemGroup>
 
     <ItemGroup>

--- a/DiscordChatExporter.Core/Models/Embed.cs
+++ b/DiscordChatExporter.Core/Models/Embed.cs
@@ -34,18 +34,18 @@ namespace DiscordChatExporter.Core.Models
 
         public IReadOnlyList<EmbedField> Fields { get; }
 
-        public IReadOnlyList<User> MentionedUsers { get; }
+        public List<User> MentionedUsers { get; }
 
-        public IReadOnlyList<Role> MentionedRoles { get; }
+        public List<Role> MentionedRoles { get; }
 
-        public IReadOnlyList<Channel> MentionedChannels { get; }
+        public List<Channel> MentionedChannels { get; }
 
         public Embed(string title, string type, string description, 
             string url, DateTime? timeStamp, Color? color, 
             EmbedFooter footer, EmbedImage image, EmbedImage thumbnail, 
             EmbedVideo video, EmbedProvider provider, EmbedAuthor author, 
-            IReadOnlyList<EmbedField> fields, IReadOnlyList<User> mentionedUsers,
-            IReadOnlyList<Role> mentionedRoles, IReadOnlyList<Channel> mentionedChannels)
+            List<EmbedField> fields, List<User> mentionedUsers,
+            List<Role> mentionedRoles, List<Channel> mentionedChannels)
         {
             Title = title;
             Type = type;

--- a/DiscordChatExporter.Core/Models/Embed.cs
+++ b/DiscordChatExporter.Core/Models/Embed.cs
@@ -35,7 +35,7 @@ namespace DiscordChatExporter.Core.Models
         public IReadOnlyList<EmbedField> Fields { get; }
 
         public Embed(string title, string type, string description, 
-            string url, DateTime? timeStamp, Color color, 
+            string url, DateTime? timeStamp, Color? color, 
             EmbedFooter footer, EmbedImage image, EmbedImage thumbnail, 
             EmbedVideo video, EmbedProvider provider, EmbedAuthor author, 
             IReadOnlyList<EmbedField> fields)

--- a/DiscordChatExporter.Core/Models/Embed.cs
+++ b/DiscordChatExporter.Core/Models/Embed.cs
@@ -6,7 +6,7 @@ using System.Drawing;
 
 namespace DiscordChatExporter.Core.Models
 {
-    public class Embed
+    public class Embed : IMentionable
     {
         public string Title { get; }
 
@@ -34,11 +34,18 @@ namespace DiscordChatExporter.Core.Models
 
         public IReadOnlyList<EmbedField> Fields { get; }
 
+        public IReadOnlyList<User> MentionedUsers { get; }
+
+        public IReadOnlyList<Role> MentionedRoles { get; }
+
+        public IReadOnlyList<Channel> MentionedChannels { get; }
+
         public Embed(string title, string type, string description, 
             string url, DateTime? timeStamp, Color? color, 
             EmbedFooter footer, EmbedImage image, EmbedImage thumbnail, 
             EmbedVideo video, EmbedProvider provider, EmbedAuthor author, 
-            IReadOnlyList<EmbedField> fields)
+            IReadOnlyList<EmbedField> fields, IReadOnlyList<User> mentionedUsers,
+            IReadOnlyList<Role> mentionedRoles, IReadOnlyList<Channel> mentionedChannels)
         {
             Title = title;
             Type = type;
@@ -53,6 +60,9 @@ namespace DiscordChatExporter.Core.Models
             Provider = provider;
             Author = author;
             Fields = fields;
+            MentionedUsers = mentionedUsers;
+            MentionedRoles = mentionedRoles;
+            MentionedChannels = mentionedChannels;
         }
 
         public override string ToString()

--- a/DiscordChatExporter.Core/Models/Embed.cs
+++ b/DiscordChatExporter.Core/Models/Embed.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+
+// https://discordapp.com/developers/docs/resources/channel#embed-object
+
+namespace DiscordChatExporter.Core.Models
+{
+    public class Embed
+    {
+        public string Title { get; }
+
+        public string Type { get; }
+
+        public string Description { get; }
+
+        public string Url { get; }
+
+        public DateTime? TimeStamp { get; }
+
+        public Color? Color { get; }
+
+        public EmbedFooter Footer { get; }
+
+        public EmbedImage Image { get; }
+
+        public EmbedImage Thumbnail { get; }
+
+        public EmbedVideo Video { get; }
+
+        public EmbedProvider Provider { get; }
+
+        public EmbedAuthor Author { get; }
+
+        public IReadOnlyList<EmbedField> Fields { get; }
+
+        public Embed(string title, string type, string description, 
+            string url, DateTime? timeStamp, Color color, 
+            EmbedFooter footer, EmbedImage image, EmbedImage thumbnail, 
+            EmbedVideo video, EmbedProvider provider, EmbedAuthor author, 
+            IReadOnlyList<EmbedField> fields)
+        {
+            Title = title;
+            Type = type;
+            Description = description;
+            Url = url;
+            TimeStamp = timeStamp;
+            Color = color;
+            Footer = footer;
+            Image = image;
+            Thumbnail = thumbnail;
+            Video = video;
+            Provider = provider;
+            Author = author;
+            Fields = fields;
+        }
+
+        public override string ToString()
+        {
+            return Description;
+        }
+    }
+}

--- a/DiscordChatExporter.Core/Models/EmbedAuthor.cs
+++ b/DiscordChatExporter.Core/Models/EmbedAuthor.cs
@@ -22,5 +22,10 @@ namespace DiscordChatExporter.Core.Models
             IconUrl = iconUrl;
             ProxyIconUrl = proxyIconUrl;
         }
+
+        public override string ToString()
+        {
+            return Name;
+        }
     }
 }

--- a/DiscordChatExporter.Core/Models/EmbedAuthor.cs
+++ b/DiscordChatExporter.Core/Models/EmbedAuthor.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+
+// https://discordapp.com/developers/docs/resources/channel#embed-object-embed-author-structure
+
+namespace DiscordChatExporter.Core.Models
+{
+    public class EmbedAuthor
+    {
+        public string Name { get; }
+
+        public string Url { get; }
+
+        public string IconUrl { get; }
+
+        public string ProxyIconUrl { get; }
+
+        public EmbedAuthor(string name, string url, string iconUrl, string proxyIconUrl)
+        {
+            Name = name;
+            Url = url;
+            IconUrl = iconUrl;
+            ProxyIconUrl = proxyIconUrl;
+        }
+    }
+}

--- a/DiscordChatExporter.Core/Models/EmbedField.cs
+++ b/DiscordChatExporter.Core/Models/EmbedField.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+
+// https://discordapp.com/developers/docs/resources/channel#embed-object-embed-field-structure
+
+namespace DiscordChatExporter.Core.Models
+{
+    public class EmbedField
+    {
+        public string Name { get; }
+
+        public string Value { get; }
+
+        public bool? Inline { get; }
+
+        public EmbedField(string name, string value, bool? inline)
+        {
+            Name = name;
+            Value = value;
+            Inline = inline;
+        }
+    }
+}

--- a/DiscordChatExporter.Core/Models/EmbedFooter.cs
+++ b/DiscordChatExporter.Core/Models/EmbedFooter.cs
@@ -19,5 +19,10 @@ namespace DiscordChatExporter.Core.Models
             IconUrl = iconUrl;
             ProxyIconUrl = proxyIconUrl;
         }
+
+        public override string ToString()
+        {
+            return Text;
+        }
     }
 }

--- a/DiscordChatExporter.Core/Models/EmbedFooter.cs
+++ b/DiscordChatExporter.Core/Models/EmbedFooter.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+
+// https://discordapp.com/developers/docs/resources/channel#embed-object-embed-footer-structure
+
+namespace DiscordChatExporter.Core.Models
+{
+    public class EmbedFooter
+    {
+        public string Text { get; }
+
+        public string IconUrl { get; }
+
+        public string ProxyIconUrl { get; }
+
+        public EmbedFooter(string text, string iconUrl, string proxyIconUrl)
+        {
+            Text = text;
+            IconUrl = iconUrl;
+            ProxyIconUrl = proxyIconUrl;
+        }
+    }
+}

--- a/DiscordChatExporter.Core/Models/EmbedImage.cs
+++ b/DiscordChatExporter.Core/Models/EmbedImage.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+
+// https://discordapp.com/developers/docs/resources/channel#embed-object-embed-image-structure
+
+namespace DiscordChatExporter.Core.Models
+{
+    public class EmbedImage
+    {
+        public string Url { get; }
+
+        public string ProxyUrl { get; }
+
+        public int? Height { get; }
+
+        public int? Width { get; }
+
+        public EmbedImage(string url, string proxyUrl, int? height, int? width)
+        {
+            Url = url;
+            ProxyUrl = proxyUrl;
+            Height = height;
+            Width = width;
+        }
+    }
+}

--- a/DiscordChatExporter.Core/Models/EmbedProvider.cs
+++ b/DiscordChatExporter.Core/Models/EmbedProvider.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+// https://discordapp.com/developers/docs/resources/channel#embed-object-embed-provider-structure
+
+namespace DiscordChatExporter.Core.Models
+{
+    public class EmbedProvider
+    {
+        public string Name { get; }
+
+        public string Url { get; }
+
+        public EmbedProvider(string name, string url)
+        {
+            Name = name;
+            Url = url;
+        }
+    }
+}

--- a/DiscordChatExporter.Core/Models/EmbedVideo.cs
+++ b/DiscordChatExporter.Core/Models/EmbedVideo.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+
+// https://discordapp.com/developers/docs/resources/channel#embed-object-embed-video-structure
+
+namespace DiscordChatExporter.Core.Models
+{
+    public class EmbedVideo
+    {
+        public string Url { get; }
+
+        public int? Height { get; }
+
+        public int? Width { get; }
+
+        public EmbedVideo(string url, int? height, int? width)
+        {
+            Url = url;
+            Height = height;
+            Width = width;
+        }
+    }
+}

--- a/DiscordChatExporter.Core/Models/IMentionable.cs
+++ b/DiscordChatExporter.Core/Models/IMentionable.cs
@@ -8,10 +8,10 @@ namespace DiscordChatExporter.Core.Models
 {
     interface IMentionable
     {
-        IReadOnlyList<User> MentionedUsers { get; }
+        List<User> MentionedUsers { get; }
 
-        IReadOnlyList<Role> MentionedRoles { get; }
+        List<Role> MentionedRoles { get; }
 
-        IReadOnlyList<Channel> MentionedChannels { get; }
+        List<Channel> MentionedChannels { get; }
     }
 }

--- a/DiscordChatExporter.Core/Models/IMentionable.cs
+++ b/DiscordChatExporter.Core/Models/IMentionable.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DiscordChatExporter.Core.Models
+{
+    interface IMentionable
+    {
+        IReadOnlyList<User> MentionedUsers { get; }
+
+        IReadOnlyList<Role> MentionedRoles { get; }
+
+        IReadOnlyList<Channel> MentionedChannels { get; }
+    }
+}

--- a/DiscordChatExporter.Core/Models/Message.cs
+++ b/DiscordChatExporter.Core/Models/Message.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace DiscordChatExporter.Core.Models
 {
-    public class Message
+    public class Message : IMentionable
     {
         public string Id { get; }
 

--- a/DiscordChatExporter.Core/Models/Message.cs
+++ b/DiscordChatExporter.Core/Models/Message.cs
@@ -21,6 +21,8 @@ namespace DiscordChatExporter.Core.Models
 
         public IReadOnlyList<Attachment> Attachments { get; }
 
+        public IReadOnlyList<Embed> Embeds { get; }
+
         public IReadOnlyList<User> MentionedUsers { get; }
 
         public IReadOnlyList<Role> MentionedRoles { get; }
@@ -30,8 +32,9 @@ namespace DiscordChatExporter.Core.Models
         public Message(string id, string channelId, MessageType type,
             User author, DateTime timeStamp,
             DateTime? editedTimeStamp, string content,
-            IReadOnlyList<Attachment> attachments, IReadOnlyList<User> mentionedUsers,
-            IReadOnlyList<Role> mentionedRoles, IReadOnlyList<Channel> mentionedChannels)
+            IReadOnlyList<Attachment> attachments, IReadOnlyList<Embed> embeds,
+            IReadOnlyList<User> mentionedUsers, IReadOnlyList<Role> mentionedRoles, 
+            IReadOnlyList<Channel> mentionedChannels)
         {
             Id = id;
             ChannelId = channelId;
@@ -41,6 +44,7 @@ namespace DiscordChatExporter.Core.Models
             EditedTimeStamp = editedTimeStamp;
             Content = content;
             Attachments = attachments;
+            Embeds = embeds;
             MentionedUsers = mentionedUsers;
             MentionedRoles = mentionedRoles;
             MentionedChannels = mentionedChannels;

--- a/DiscordChatExporter.Core/Models/Message.cs
+++ b/DiscordChatExporter.Core/Models/Message.cs
@@ -23,18 +23,18 @@ namespace DiscordChatExporter.Core.Models
 
         public IReadOnlyList<Embed> Embeds { get; }
 
-        public IReadOnlyList<User> MentionedUsers { get; }
+        public List<User> MentionedUsers { get; }
 
-        public IReadOnlyList<Role> MentionedRoles { get; }
+        public List<Role> MentionedRoles { get; }
 
-        public IReadOnlyList<Channel> MentionedChannels { get; }
+        public List<Channel> MentionedChannels { get; }
 
         public Message(string id, string channelId, MessageType type,
             User author, DateTime timeStamp,
             DateTime? editedTimeStamp, string content,
             IReadOnlyList<Attachment> attachments, IReadOnlyList<Embed> embeds,
-            IReadOnlyList<User> mentionedUsers, IReadOnlyList<Role> mentionedRoles, 
-            IReadOnlyList<Channel> mentionedChannels)
+            List<User> mentionedUsers, List<Role> mentionedRoles, 
+            List<Channel> mentionedChannels)
         {
             Id = id;
             ChannelId = channelId;

--- a/DiscordChatExporter.Core/Models/User.cs
+++ b/DiscordChatExporter.Core/Models/User.cs
@@ -2,7 +2,7 @@
 
 namespace DiscordChatExporter.Core.Models
 {
-    public class User
+    public partial class User
     {
         public string Id { get; }
 
@@ -31,6 +31,14 @@ namespace DiscordChatExporter.Core.Models
         public override string ToString()
         {
             return FullName;
+        }
+    }
+
+    public partial class User
+    {
+        public static User CreateUnknownUser(string id)
+        {
+            return new User(id, 0, "Unknown", null);
         }
     }
 }

--- a/DiscordChatExporter.Core/Resources/ExportService/DarkTheme.css
+++ b/DiscordChatExporter.Core/Resources/ExportService/DarkTheme.css
@@ -140,3 +140,34 @@ img.emoji {
 span.mention {
     font-weight: 600;
 }
+
+.embed-wrapper .embed-color-pill {
+    background-color: #4f545c
+}
+
+.embed {
+    background-color: rgba(46, 48, 54, .3);
+    border-color: rgba(46, 48, 54, .6)
+}
+
+.embed .embed-footer,
+.embed .embed-provider {
+    color: hsla(0, 0%, 100%, .6)
+}
+
+.embed .embed-author-name {
+    color: #fff!important
+}
+
+.embed div.embed-title {
+    color: #fff
+}
+
+.embed .embed-description,
+.embed .embed-fields {
+    color: hsla(0, 0%, 100%, .6)
+}
+
+.embed .embed-fields .embed-field-name {
+    color: #fff
+}

--- a/DiscordChatExporter.Core/Resources/ExportService/DarkTheme.css
+++ b/DiscordChatExporter.Core/Resources/ExportService/DarkTheme.css
@@ -1,144 +1,47 @@
 ﻿body {
     background-color: #36393E;
     color: rgba(255, 255, 255, 0.7);
-    font-family: Whitney, Helvetica Neue, Helvetica, Arial, sans-serif;
-    font-size: 16px;
 }
 
 a {
     color: #0096CF;
-    text-decoration: none;
-}
-
-a:hover {
-     text-decoration: underline;
 }
 
 div.pre {
     background-color: #2F3136;
     color: rgb(131, 148, 150);
-    font-family: Consolas, Courier New, Courier, Monospace;
-    margin-top: 4px;
-    padding: 8px;
-    white-space: pre-wrap;
 }
 
 span.pre {
     background-color: #2F3136;
-    font-family: Consolas, Courier New, Courier, Monospace;
-    padding-left: 2px;
-    padding-right: 2px;
-    white-space: pre-wrap;
-}
-
-div#info {
-    display: flex;
-    margin-bottom: 10px;
-    margin-left: 5px;
-    margin-right: 5px;
-    max-width: 100%;
-}
-
-div#log {
-     max-width: 100%;
-}
-
-img.guild-icon {
-    max-height: 64px;
-    max-width: 64px;
-}
-
-div.info-right {
-    flex: 1;
-    margin-left: 10px;
 }
 
 div.guild-name {
     color: #FFFFFF;
-    font-size: 1.4em;
 }
 
 div.channel-name {
     color: #FFFFFF;
-    font-size: 1.2em;
 }
 
 div.channel-topic {
-    margin-top: 2px;
     color: #FFFFFF;
-}
-
-div.channel-messagecount {
-    margin-top: 2px;
 }
 
 div.msg {
     border-top: 1px solid rgba(255, 255, 255, 0.04);
-    display: flex;
-    margin-left: 10px;
-    margin-right: 10px;
-    padding-bottom: 15px;
-    padding-top: 15px;
-}
-
-div.msg-left {
-    height: 40px;
-    width: 40px;
-}
-
-img.msg-avatar {
-    border-radius: 50%;
-    height: 40px;
-    width: 40px;
-}
-
-div.msg-right {
-    flex: 1;
-    margin-left: 20px;
-    min-width: 50%;
 }
 
 span.msg-user {
     color: #FFFFFF;
-    font-size: 1em;
 }
 
 span.msg-date {
     color: rgba(255, 255, 255, 0.2);
-    font-size: .75em;
-    margin-left: 5px;
 }
 
 span.msg-edited {
     color: rgba(255, 255, 255, 0.2);
-    font-size: .8em;
-    margin-left: 5px;
-}
-
-div.msg-content {
-    font-size: .9375em;
-    padding-top: 5px;
-    word-wrap: break-word;
-}
-
-div.msg-attachment {
-    margin-bottom: 5px;
-    margin-top: 5px;
-}
-
-img.msg-attachment {
-    max-height: 500px;
-    max-width: 50%;
-}
-
-img.emoji {
-    height: 24px;
-    width: 24px;
-    vertical-align: -.4em;
-}
-
-span.mention {
-    font-weight: 600;
 }
 
 .embed-wrapper .embed-color-pill {

--- a/DiscordChatExporter.Core/Resources/ExportService/LightTheme.css
+++ b/DiscordChatExporter.Core/Resources/ExportService/LightTheme.css
@@ -1,142 +1,45 @@
 ﻿body {
     background-color: #FFFFFF;
     color: #737F8D;
-    font-family: Whitney, Helvetica Neue, Helvetica, Arial, sans-serif;
-    font-size: 16px;
 }
 
 a {
     color: #00B0F4;
-    text-decoration: none;
-}
-
-a:hover {
-     text-decoration: underline;
 }
 
 div.pre {
     background-color: #F9F9F9;
     color: rgb(101, 123, 131);
-    font-family: Consolas, Courier New, Courier, Monospace;
-    margin-top: 4px;
-    padding: 8px;
-    white-space: pre-wrap;
 }
 
 span.pre {
     background-color: #F9F9F9;
-    font-family: Consolas, Courier New, Courier, Monospace;
-    padding-left: 2px;
-    padding-right: 2px;
-    white-space: pre-wrap;
-}
-
-div#info {
-    display: flex;
-    margin-bottom: 10px;
-    margin-left: 5px;
-    margin-right: 5px;
-    max-width: 100%;
-}
-
-div#log {
-     max-width: 100%;
-}
-
-img.guild-icon {
-    max-height: 64px;
-    max-width: 64px;
-}
-
-div.info-right {
-    flex: 1;
-    margin-left: 10px;
 }
 
 div.guild-name {
     color: #2F3136;
-    font-size: 1.4em;
 }
 
 div.channel-name {
     color: #2F3136;
-    font-size: 1.2em;
 }
 
 div.channel-topic {
-    margin-top: 2px;
     color: #2F3136;
-}
-
-div.channel-messagecount {
-    margin-top: 2px;
 }
 
 div.msg {
     border-top: 1px solid #ECEEEF;
-    display: flex;
-    margin-left: 10px;
-    margin-right: 10px;
-    padding-bottom: 15px;
-    padding-top: 15px;
-}
-
-div.msg-left {
-    height: 40px;
-    width: 40px;
-}
-
-img.msg-avatar {
-    border-radius: 50%;
-    height: 40px;
-    width: 40px;
-}
-
-div.msg-right {
-    flex: 1;
-    margin-left: 20px;
-    min-width: 50%;
 }
 
 span.msg-user {
     color: #2F3136;
-    font-size: 1em;
 }
 
 span.msg-date {
     color: #99AAB5;
-    font-size: .75em;
-    margin-left: 5px;
 }
 
 span.msg-edited {
     color: #99AAB5;
-    font-size: .8em;
-    margin-left: 5px;
-}
-
-div.msg-content {
-    font-size: .9375em;
-    padding-top: 5px;
-    word-wrap: break-word;
-}
-
-div.msg-attachment {
-    margin-bottom: 5px;
-    margin-top: 5px;
-}
-
-img.msg-attachment {
-    max-height: 500px;
-    max-width: 50%;
-}
-
-img.emoji {
-    height: 24px;
-    width: 24px;
-    vertical-align: -.4em;
-}
-
-span.mention {
-    font-weight: 600;
 }

--- a/DiscordChatExporter.Core/Resources/ExportService/Shared.css
+++ b/DiscordChatExporter.Core/Resources/ExportService/Shared.css
@@ -120,6 +120,8 @@ img.msg-attachment {
 
 span.mention {
     font-weight: 600;
+    color: #7289da;
+    background-color: rgba(115, 139, 215, 0.1);
 }
 
 .emoji {

--- a/DiscordChatExporter.Core/Resources/ExportService/Shared.css
+++ b/DiscordChatExporter.Core/Resources/ExportService/Shared.css
@@ -260,7 +260,9 @@
 }
 
 .embed .embed-thumbnail img {
-    margin: 0
+    margin: 0;
+    max-width: 500px;
+    max-height: 400px;
 }
 
 .comment>:last-child .embed {

--- a/DiscordChatExporter.Core/Resources/ExportService/Shared.css
+++ b/DiscordChatExporter.Core/Resources/ExportService/Shared.css
@@ -1,8 +1,132 @@
+body {
+    font-family: Whitney, Helvetica Neue, Helvetica, Arial, sans-serif;
+    font-size: 16px;
+}
+
+a {
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+div.pre {
+    font-family: Consolas, Courier New, Courier, Monospace;
+    margin-top: 4px;
+    padding: 8px;
+    white-space: pre-wrap;
+}
+
+span.pre {
+    font-family: Consolas, Courier New, Courier, Monospace;
+    padding-left: 2px;
+    padding-right: 2px;
+    white-space: pre-wrap;
+}
+
+div#info {
+    display: flex;
+    margin-bottom: 10px;
+    margin-left: 5px;
+    margin-right: 5px;
+    max-width: 100%;
+}
+
+div#log {
+    max-width: 100%;
+}
+
+img.guild-icon {
+    max-height: 64px;
+    max-width: 64px;
+}
+
+div.info-right {
+    flex: 1;
+    margin-left: 10px;
+}
+
+div.guild-name {
+    font-size: 1.4em;
+}
+
+div.channel-name {
+    font-size: 1.2em;
+}
+
+div.channel-topic {
+    margin-top: 2px;
+}
+
+div.channel-messagecount {
+    margin-top: 2px;
+}
+
+div.msg {
+    display: flex;
+    margin-left: 10px;
+    margin-right: 10px;
+    padding-bottom: 15px;
+    padding-top: 15px;
+}
+
+div.msg-left {
+    height: 40px;
+    width: 40px;
+}
+
+img.msg-avatar {
+    border-radius: 50%;
+    height: 40px;
+    width: 40px;
+}
+
+div.msg-right {
+    flex: 1;
+    margin-left: 20px;
+    min-width: 50%;
+}
+
+span.msg-user {
+    font-size: 1em;
+}
+
+span.msg-date {
+    font-size: .75em;
+    margin-left: 5px;
+}
+
+span.msg-edited {
+    font-size: .8em;
+    margin-left: 5px;
+}
+
+div.msg-content {
+    font-size: .9375em;
+    padding-top: 5px;
+    word-wrap: break-word;
+}
+
+div.msg-attachment {
+    margin-bottom: 5px;
+    margin-top: 5px;
+}
+
+img.msg-attachment {
+    max-height: 500px;
+    max-width: 50%;
+}
+
+span.mention {
+    font-weight: 600;
+}
+
 .emoji {
     -o-object-fit: contain;
     object-fit: contain;
-    width: 22px;
-    height: 22px;
+    width: 24px;
+    height: 24px;
     margin: 0 .05em 0 .1em!important;
     vertical-align: -.4em
 }

--- a/DiscordChatExporter.Core/Resources/ExportService/Shared.css
+++ b/DiscordChatExporter.Core/Resources/ExportService/Shared.css
@@ -1,0 +1,268 @@
+.emoji {
+    -o-object-fit: contain;
+    object-fit: contain;
+    width: 22px;
+    height: 22px;
+    margin: 0 .05em 0 .1em!important;
+    vertical-align: -.4em
+}
+
+.emoji.jumboable {
+    width: 32px;
+    height: 32px
+}
+
+.image {
+    display: inline-block;
+    position: relative;
+    -webkit-user-select: text;
+    -moz-user-select: text;
+    -ms-user-select: text;
+    user-select: text
+}
+
+.embed,
+.embed-wrapper {
+    display: -webkit-box;
+    display: -ms-flexbox
+}
+
+.embed-wrapper {
+    position: relative;
+    margin-top: 5px;
+    max-width: 520px;
+    display: flex
+}
+
+.embed-wrapper .embed-color-pill {
+    width: 4px;
+    background: #cacbce;
+    border-radius: 3px 0 0 3px;
+    -ms-flex-negative: 0;
+    flex-shrink: 0
+}
+
+.embed {
+    padding: 8px 10px;
+    box-sizing: border-box;
+    background: hsla(0, 0%, 98%, .3);
+    border: 1px solid hsla(0, 0%, 80%, .3);
+    border-radius: 0 3px 3px 0;
+    display: flex;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: column;
+    flex-direction: column
+}
+
+.embed .embed-content,
+.embed.embed-rich {
+    display: -webkit-box;
+    display: -ms-flexbox
+}
+
+.embed .embed-fields,
+.embed.embed-link {
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal
+}
+
+.embed div.embed-title {
+    color: #4f545c
+}
+
+.embed .embed-content {
+    width: 100%;
+    display: flex;
+    margin-bottom: 10px
+}
+
+.embed .embed-content .embed-content-inner {
+    -webkit-box-flex: 1;
+    -ms-flex: 1;
+    flex: 1
+}
+
+.embed.embed-rich {
+    position: relative;
+    display: flex;
+    border-radius: 0 3px 3px 0
+}
+
+.embed.embed-rich .embed-rich-thumb {
+    max-height: 80px;
+    max-width: 80px;
+    border-radius: 3px;
+    width: auto;
+    -o-object-fit: contain;
+    object-fit: contain;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    margin-left: 20px
+}
+
+.embed.embed-inline {
+    padding: 0;
+    margin: 4px 0;
+    border-radius: 3px
+}
+
+.embed .image,
+.embed video {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    overflow: hidden;
+    border-radius: 2px
+}
+
+.embed .embed-content-inner>:last-child,
+.embed .embed-content:last-child,
+.embed .embed-inner>:last-child,
+.embed>:last-child {
+    margin-bottom: 0!important
+}
+
+.embed .embed-provider {
+    display: inline-block;
+    color: #87909c;
+    font-weight: 400;
+    font-size: 12px;
+    margin-bottom: 5px
+}
+
+.embed .embed-author {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    margin-bottom: 5px
+}
+
+.embed .embed-author-name,
+.embed .embed-footer,
+.embed .embed-title {
+    display: inline-block;
+    font-weight: 600
+}
+
+.embed .embed-author-name {
+    font-size: 14px;
+    color: #4f545c!important
+}
+
+.embed .embed-author-icon {
+    margin-right: 9px;
+    width: 20px;
+    height: 20px;
+    -o-object-fit: contain;
+    object-fit: contain;
+    border-radius: 50%
+}
+
+.embed .embed-footer {
+    font-size: 12px;
+    color: rgba(79, 83, 91, .6);
+    letter-spacing: 0
+}
+
+.embed .embed-footer-icon {
+    margin-right: 10px;
+    height: 18px;
+    width: 18px;
+    -o-object-fit: contain;
+    object-fit: contain;
+    float: left;
+    border-radius: 2.45px
+}
+
+.embed .embed-title {
+    margin-bottom: 4px;
+    font-size: 14px
+}
+
+.embed .embed-title+.embed-description {
+    margin-top: -3px!important
+}
+
+.embed .embed-description {
+    display: block;
+    font-size: 14px;
+    font-weight: 500;
+    margin-bottom: 10px;
+    color: rgba(79, 83, 91, .9);
+    letter-spacing: 0
+}
+
+.embed .embed-description.markup {
+    white-space: pre-line;
+    margin-top: 0!important;
+    font-size: 14px!important;
+    line-height: 16px!important
+}
+
+.embed .embed-description.markup pre {
+    max-width: 100%!important
+}
+
+.embed .embed-fields {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-direction: row;
+    flex-direction: row;
+    -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
+    color: #36393e;
+    margin-top: -10px;
+    margin-bottom: 10px
+}
+
+.embed .embed-fields .embed-field {
+    -webkit-box-flex: 0;
+    -ms-flex: 0;
+    flex: 0;
+    padding-top: 10px;
+    min-width: 100%;
+    max-width: 506px
+}
+
+.embed .embed-fields .embed-field.embed-field-inline {
+    -webkit-box-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+    min-width: 150px;
+    -ms-flex-preferred-size: auto;
+    flex-basis: auto
+}
+
+.embed .embed-fields .embed-field .embed-field-name {
+    font-size: 14px;
+    margin-bottom: 4px;
+    font-weight: 600
+}
+
+.embed .embed-fields .embed-field .embed-field-value {
+    font-size: 14px;
+    font-weight: 500
+}
+
+.embed .embed-thumbnail,
+.embed .embed-thumbnail-gifv {
+    position: relative;
+    display: inline-block
+}
+
+.embed .embed-thumbnail {
+    margin-bottom: 10px
+}
+
+.embed .embed-thumbnail img {
+    margin: 0
+}
+
+.comment>:last-child .embed {
+    margin-bottom: auto
+}

--- a/DiscordChatExporter.Core/Services/DataService.cs
+++ b/DiscordChatExporter.Core/Services/DataService.cs
@@ -197,7 +197,12 @@ namespace DiscordChatExporter.Core.Services
                         fieldNode["inline"]?.Value<bool>()));
                 }
 
-                var embed = new Embed(embedTitle, embedType, embedDescription, embedUrl, embedTimeStamp, embedColor, embedFooter, embedImage, embedThumbnail, embedVideo, embedProvider, embedAuthor, embedFields);
+                var embed = new Embed(
+                    embedTitle, embedType, embedDescription, 
+                    embedUrl, embedTimeStamp, embedColor, 
+                    embedFooter, embedImage, embedThumbnail, 
+                    embedVideo, embedProvider, embedAuthor, 
+                    embedFields);
                 embeds.Add(embed);
             }
 

--- a/DiscordChatExporter.Core/Services/ExportService.Html.cs
+++ b/DiscordChatExporter.Core/Services/ExportService.Html.cs
@@ -121,7 +121,7 @@ namespace DiscordChatExporter.Core.Services
             if (color != null)
                 backgroundColor = $"rgba({color?.R},{color?.G},{color?.B},1)";
 
-            return $"<div class='embed-color-pill' style='background-color: {backgroundColor}' />";
+            return $"<div class='embed-color-pill' style='background-color: {backgroundColor}'></div>";
         }
 
         private string EmbedTitleToHtml(string title, string url)

--- a/DiscordChatExporter.Core/Services/ExportService.Html.cs
+++ b/DiscordChatExporter.Core/Services/ExportService.Html.cs
@@ -31,7 +31,7 @@ namespace DiscordChatExporter.Core.Services
 
             // Encode URLs
             content = Regex.Replace(content,
-                @"(?:[^\\(]|^)((https?|ftp)://[-a-zA-Z0-9+&@#/%?=~_|!:,\.\[\]\(\);]*[-a-zA-Z0-9+&@#/%=~_|\[\])])(?=$|\W)",
+                @"(\b(?:(?:https?|ftp|file)://|www\.|ftp\.)(?:\([-a-zA-Z0-9+&@#/%?=~_|!:,\.\[\];]*\)|[-a-zA-Z0-9+&@#/%?=~_|!:,\.\[\];])*(?:\([-a-zA-Z0-9+&@#/%?=~_|!:,\.\[\];]*\)|[-a-zA-Z0-9+&@#/%=~_|$]))",
                 m => $"\x1AL{Base64Encode(m.Groups[1].Value)}\x1AL");
 
             // Process bold (**text**)
@@ -54,6 +54,12 @@ namespace DiscordChatExporter.Core.Services
             content = Regex.Replace(content, "\x1AI(.*?)\x1AI",
                 m => $"<span class=\"pre\">{Base64Decode(m.Groups[1].Value)}</span>");
 
+            if (allowLinks)
+            {
+                content = Regex.Replace(content, "\\[([^\\]]+)\\]\\(\x1AL(.*?)\x1AL\\)",
+                    m => $"<a href=\"{Base64Decode(m.Groups[2].Value)}\">{m.Groups[1].Value}</a>");
+            }
+
             // Decode and process URLs
             content = Regex.Replace(content, "\x1AL(.*?)\x1AL",
                 m => $"<a href=\"{Base64Decode(m.Groups[1].Value)}\">{Base64Decode(m.Groups[1].Value)}</a>");
@@ -70,13 +76,6 @@ namespace DiscordChatExporter.Core.Services
             // Custom emojis (<:name:id>)
             content = Regex.Replace(content, "&lt;(:.*?:)(\\d*)&gt;",
                 "<img class=\"emoji\" title=\"$1\" src=\"https://cdn.discordapp.com/emojis/$2.png\" />");
-
-            // Markdown links
-            if (allowLinks)
-            {
-                content = Regex.Replace(content, "\\[([^\\]]+)\\]\\(([^\\)]+)\\)", 
-                    "<a href=\"$2\">$1</a>");
-            }
 
             return content;
         }

--- a/DiscordChatExporter.Core/Services/ExportService.Html.cs
+++ b/DiscordChatExporter.Core/Services/ExportService.Html.cs
@@ -31,7 +31,7 @@ namespace DiscordChatExporter.Core.Services
 
             // Encode URLs
             content = Regex.Replace(content,
-                @"((https?|ftp)://[-a-zA-Z0-9+&@#/%?=~_|!:,\.\[\]\(\);]*[-a-zA-Z0-9+&@#/%=~_|\[\])])(?=$|\W)",
+                @"(?:[^\\(]|^)((https?|ftp)://[-a-zA-Z0-9+&@#/%?=~_|!:,\.\[\]\(\);]*[-a-zA-Z0-9+&@#/%=~_|\[\])])(?=$|\W)",
                 m => $"\x1AL{Base64Encode(m.Groups[1].Value)}\x1AL");
 
             // Process bold (**text**)
@@ -70,9 +70,13 @@ namespace DiscordChatExporter.Core.Services
             // Custom emojis (<:name:id>)
             content = Regex.Replace(content, "&lt;(:.*?:)(\\d*)&gt;",
                 "<img class=\"emoji\" title=\"$1\" src=\"https://cdn.discordapp.com/emojis/$2.png\" />");
-            
+
             // Markdown links
-            // TODO: add links parsing here when `allowLinks` is true
+            if (allowLinks)
+            {
+                content = Regex.Replace(content, "\\[([^\\]]+)\\]\\(([^\\)]+)\\)", 
+                    "<a href=\"$2\">$1</a>");
+            }
 
             return content;
         }
@@ -146,8 +150,7 @@ namespace DiscordChatExporter.Core.Services
 
         private string EmbedAuthorToHtml(string name, string url, string icon_url)
         {
-
-            if (name != null)
+            if (name == null)
                 return null;
 
             string authorName = null;

--- a/DiscordChatExporter.Core/Services/ExportService.cs
+++ b/DiscordChatExporter.Core/Services/ExportService.cs
@@ -22,25 +22,25 @@ namespace DiscordChatExporter.Core.Services
         {
             using (var output = File.CreateText(filePath))
             {
+                var sharedCss = Assembly.GetExecutingAssembly()
+                        .GetManifestResourceString("DiscordChatExporter.Core.Resources.ExportService.Shared.css");
+
                 if (format == ExportFormat.PlainText)
                 {
                     await ExportAsPlainTextAsync(log, output);
                 }
-
                 else if (format == ExportFormat.HtmlDark)
                 {
                     var css = Assembly.GetExecutingAssembly()
                         .GetManifestResourceString("DiscordChatExporter.Core.Resources.ExportService.DarkTheme.css");
-                    await ExportAsHtmlAsync(log, output, css);
+                    await ExportAsHtmlAsync(log, output, $"{sharedCss}\n{css}");
                 }
-
                 else if (format == ExportFormat.HtmlLight)
                 {
                     var css = Assembly.GetExecutingAssembly()
                         .GetManifestResourceString("DiscordChatExporter.Core.Resources.ExportService.LightTheme.css");
-                    await ExportAsHtmlAsync(log, output, css);
+                    await ExportAsHtmlAsync(log, output, $"{sharedCss}\n{css}");
                 }
-
                 else if (format == ExportFormat.Csv)
                 {
                     await ExportAsCsvAsync(log, output);


### PR DESCRIPTION
Most of the work for converting the embeds to html was already done in this [Embed Visualizer](https://leovoel.github.io/embed-visualizer/), so once I converted that javascript into C#, I only had to make some adjustments to get it working nicely.

Let me know if there is anything I should do differently or anything.

One thing to note is that it currently doesn't support converting mentions in the embed descriptions. This is a bit tricky to add because we don't have the list of mentions like the main message does. We'll have to query to get users for that server I think. Let me know if you think of a better way to do it.

**Example Channel Conversion:**
I converted a channel from my bot's help server as an example:
Discord Channel Link: https://discord.gg/KAAfs2A
File (zipped because GitHub doesn't let me attach html): [Mangobyte Info - demos-examples.html.zip](https://github.com/Tyrrrz/DiscordChatExporter/files/1926885/Mangobyte.Info.-.demos-examples.html.zip)

**Example Embed:**

Embed output html:
![image](https://user-images.githubusercontent.com/3231343/38975266-198a9f64-4362-11e8-80ff-6fd916b4c2c5.png)

Embed viewed in Discord App:
![image](https://user-images.githubusercontent.com/3231343/38975288-2c9c7730-4362-11e8-9516-7a9a6b8b353d.png)

implements #42