### PR TITLE
Dockerize the application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM mono:5
+WORKDIR /root/build
+COPY DiscordChatExporter.sln favicon.ico ./
+COPY DiscordChatExporter.Core DiscordChatExporter.Core
+COPY DiscordChatExporter.Cli DiscordChatExporter.Cli
+RUN msbuild ./DiscordChatExporter.Cli/DiscordChatExporter.Cli.csproj /t:Restore
+RUN msbuild ./DiscordChatExporter.Cli/DiscordChatExporter.Cli.csproj /p:Configuration=Release
+
+FROM mono:5
+COPY --from=0 /root/build/DiscordChatExporter.Cli/bin/Release/net461 /root/bin
+WORKDIR /a
+ENTRYPOINT ["mono", "/root/bin/DiscordChatExporter.Cli.exe"]


### PR DESCRIPTION
Thank you for making the awesome application! Since you have separated the CLI version, macOS and Linux users can use DiscordChatExporter conveniently by Docker!

```bash
docker run "-v${PWD}:/a" simnalamburt/discordchatexporter export -c <CHANNEL ID> -t <TOKEN>
```

###### Reference
- https://hub.docker.com/r/simnalamburt/discordchatexporter/