### PR TITLE
Add bot tags and some CSS fixes

### DIFF
--- a/DiscordChatExporter.Core.Models/User.cs
+++ b/DiscordChatExporter.Core.Models/User.cs
@@ -19,12 +19,15 @@ namespace DiscordChatExporter.Core.Models
 
         public string AvatarUrl { get; }
 
-        public User(string id, int discriminator, string name, string avatarHash)
+        public bool IsBot { get; }
+
+        public User(string id, int discriminator, string name, string avatarHash, bool isBot)
         {
             Id = id;
             Discriminator = discriminator;
             Name = name;
             AvatarHash = avatarHash;
+            IsBot = isBot;
 
             FullName = GetFullName(name, discriminator);
             AvatarUrl = GetAvatarUrl(id, discriminator, avatarHash);
@@ -54,6 +57,6 @@ namespace DiscordChatExporter.Core.Models
             return $"https://cdn.discordapp.com/embed/avatars/{discriminator % 5}.png";
         }
 
-        public static User CreateUnknownUser(string id) => new User(id, 0, "Unknown", null);
+        public static User CreateUnknownUser(string id) => new User(id, 0, "Unknown", null, false);
     }
 }

--- a/DiscordChatExporter.Core.Rendering/Resources/HtmlShared.css
+++ b/DiscordChatExporter.Core.Rendering/Resources/HtmlShared.css
@@ -341,3 +341,16 @@ img {
     margin-left: 6px;
     font-size: .875em;
 }
+
+.chatlog__bot-tag {
+    margin-left: 0.3em;
+    background: #7289da;
+    color: #ffffff;
+    font-size: 0.625em;
+    padding: 1px 2px;
+    border-radius: 3px;
+    vertical-align: middle;
+    line-height: 1.3;
+    position: relative;
+    top: -.2em;
+}

--- a/DiscordChatExporter.Core.Rendering/Resources/HtmlShared.css
+++ b/DiscordChatExporter.Core.Rendering/Resources/HtmlShared.css
@@ -289,7 +289,7 @@ img {
 }
 
 .chatlog__embed-footer-text {
-    font-weight: 600;
+    font-weight: 500;
     font-size: .75em;
 }
 

--- a/DiscordChatExporter.Core.Rendering/Resources/HtmlShared.css
+++ b/DiscordChatExporter.Core.Rendering/Resources/HtmlShared.css
@@ -41,6 +41,7 @@ img {
 .pre--inline {
     padding: 2px;
     border-radius: 3px;
+    font-size: 85%;
 }
 
 .mention {

--- a/DiscordChatExporter.Core.Rendering/Resources/HtmlShared.css
+++ b/DiscordChatExporter.Core.Rendering/Resources/HtmlShared.css
@@ -1,5 +1,35 @@
 /* === GENERAL === */
 
+@font-face {
+    font-family: Whitney;
+    src: url(https://discordapp.com/assets/6c6374bad0b0b6d204d8d6dc4a18d820.woff);
+    font-weight: 300;
+}
+
+@font-face {
+    font-family: Whitney;
+    src: url(https://discordapp.com/assets/e8acd7d9bf6207f99350ca9f9e23b168.woff);
+    font-weight: 400;
+}
+
+@font-face {
+    font-family: Whitney;
+    src: url(https://discordapp.com/assets/3bdef1251a424500c1b3a78dea9b7e57.woff);
+    font-weight: 500;
+}
+
+@font-face {
+    font-family: Whitney;
+    src: url(https://discordapp.com/assets/be0060dafb7a0e31d2a1ca17c0708636.woff);
+    font-weight: 600;
+}
+
+@font-face {
+    font-family: Whitney;
+    src: url(https://discordapp.com/assets/8e12fb4f14d9c4592eb8ec9f22337b04.woff);
+    font-weight: 700;
+}
+
 body {
     font-family: "Whitney", "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 16px;

--- a/DiscordChatExporter.Core.Rendering/Resources/HtmlShared.html
+++ b/DiscordChatExporter.Core.Rendering/Resources/HtmlShared.html
@@ -68,6 +68,9 @@
             <div class="chatlog__messages">
                 {{~ # Author name and timestamp ~}}
                 <span class="chatlog__author-name" title="{{ group.Author.FullName | html.escape }}">{{ group.Author.Name | html.escape }}</span>
+                {{~ if group.Author.IsBot ~}}
+                    <span class="chatlog__bot-tag">BOT</span>
+                {{~ end ~}}
                 <span class="chatlog__timestamp">{{ group.Timestamp | FormatDate | html.escape }}</span>
 
                 {{~ # Messages ~}}

--- a/DiscordChatExporter.Core.Services/DataService.Parsers.cs
+++ b/DiscordChatExporter.Core.Services/DataService.Parsers.cs
@@ -16,8 +16,9 @@ namespace DiscordChatExporter.Core.Services
             var discriminator = json["discriminator"].Value<int>();
             var name = json["username"].Value<string>();
             var avatarHash = json["avatar"].Value<string>();
+            var isBot = json["bot"]?.Value<bool>() ?? false;
 
-            return new User(id, discriminator, name, avatarHash);
+            return new User(id, discriminator, name, avatarHash, isBot);
         }
 
         private Guild ParseGuild(JToken json)


### PR DESCRIPTION
- Fixes a couple things in the discord css
- Adds the discord font so everything looks nice
- Adds support for is_bot so that we can add bot tags in the html

Looks like this:
![image](https://user-images.githubusercontent.com/3231343/57345204-d17ac980-70fe-11e9-97d4-bc2e795e3daa.png)

I'm not sure if we would want to add the is_bot to the other kinds of output, but I can add that if you want!