### PR TITLE
Change CSV renderer to use commas instead of semicolons

### DIFF
--- a/DiscordChatExporter.Core.Rendering/CsvChatLogRenderer.cs
+++ b/DiscordChatExporter.Core.Rendering/CsvChatLogRenderer.cs
@@ -81,7 +81,7 @@ namespace DiscordChatExporter.Core.Rendering
         private async Task RenderFieldAsync(TextWriter writer, string value)
         {
             var encodedValue = value.Replace("\"", "\"\"");
-            await writer.WriteAsync($"\"{encodedValue}\";");
+            await writer.WriteAsync($"\"{encodedValue}\",");
         }
 
         private async Task RenderMessageAsync(TextWriter writer, Message message)


### PR DESCRIPTION
The current delimiter is a semicolon, and normally CSVs are delimited by commas.