### PR TITLE
Add support for Guild Member object & included data

### DIFF
--- a/DiscordChatExporter.Cli/Program.cs
+++ b/DiscordChatExporter.Cli/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Drawing;
 using System.Threading.Tasks;
 using CliFx;
 using DiscordChatExporter.Cli.Commands;

--- a/DiscordChatExporter.Core.Models/Guild.cs
+++ b/DiscordChatExporter.Core.Models/Guild.cs
@@ -44,7 +44,7 @@ namespace DiscordChatExporter.Core.Models
                 )?.Where(r => r.Color != 0)?
                 .Aggregate(Role.Everyone, (a, b) => a.Position > b.Position? a : b)?
                 .ColorAsHex ?? "";
-        public static string GetUserNick(Guild guild, User user) => guild.Members[user.Id]?.Nick ?? user.Name;
+        public static string GetUserNick(Guild guild, User user) => guild.Members.GetValueOrDefault(user.Id)?.Nick ?? user.Name;
 
         public static string GetIconUrl(string id, string? iconHash)
         {

--- a/DiscordChatExporter.Core.Models/Guild.cs
+++ b/DiscordChatExporter.Core.Models/Guild.cs
@@ -42,7 +42,7 @@ namespace DiscordChatExporter.Core.Models
                             .Where(role => r == role.Id)
                             .FirstOrDefault()
                 )?.Where(r => r.Color != 0)?
-                .Aggregate(Role.Everyone, (a, b) => a.Position > b.Position? a : b)?
+                .Aggregate<Role, Role?>(null, (a, b) => (a?.Position ?? 0) > b.Position? a : b)?
                 .ColorAsHex ?? "";
         public static string GetUserNick(Guild guild, User user) => guild.Members.GetValueOrDefault(user.Id)?.Nick ?? user.Name;
 

--- a/DiscordChatExporter.Core.Models/Guild.cs
+++ b/DiscordChatExporter.Core.Models/Guild.cs
@@ -1,4 +1,8 @@
-﻿namespace DiscordChatExporter.Core.Models
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DiscordChatExporter.Core.Models
 {
     // https://discordapp.string.IsNullOrWhiteSpace(com/developers/docs/resources/guild#guild-object
 
@@ -10,13 +14,19 @@
 
         public string? IconHash { get; }
 
+        public List<Role> Roles { get; }
+
+        public Dictionary<string, Member?> Members { get; }
+
         public string IconUrl { get; }
 
-        public Guild(string id, string name, string? iconHash)
+        public Guild(string id, string name, List<Role> roles, string? iconHash)
         {
             Id = id;
             Name = name;
             IconHash = iconHash;
+            Roles = roles;
+            Members = new Dictionary<string, Member?>();
 
             IconUrl = GetIconUrl(id, iconHash);
         }
@@ -26,6 +36,15 @@
 
     public partial class Guild
     {
+        public static string GetUserColor(Guild guild, User user) => 
+                guild.Members.GetValueOrDefault(user.Id, null)?.Roles
+                ?.Select(r => guild.Roles
+                            .Where(role => r == role.Id)
+                            .FirstOrDefault()
+                )?.FirstOrDefault()?
+                .ColorAsHex ?? "#FFFFFF";
+        public static string GetUserNick(Guild guild, User user) => guild.Members[user.Id]?.Nick ?? user.Name;
+
         public static string GetIconUrl(string id, string? iconHash)
         {
             return !string.IsNullOrWhiteSpace(iconHash)
@@ -33,6 +52,6 @@
                 : "https://cdn.discordapp.com/embed/avatars/0.png";
         }
 
-        public static Guild DirectMessages { get; } = new Guild("@me", "Direct Messages", null);
+        public static Guild DirectMessages { get; } = new Guild("@me", "Direct Messages", new List<Role>(), null);
     }
 }

--- a/DiscordChatExporter.Core.Models/Guild.cs
+++ b/DiscordChatExporter.Core.Models/Guild.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 
 namespace DiscordChatExporter.Core.Models
@@ -14,13 +15,13 @@ namespace DiscordChatExporter.Core.Models
 
         public string? IconHash { get; }
 
-        public List<Role> Roles { get; }
+        public IReadOnlyList<Role> Roles { get; }
 
         public Dictionary<string, Member?> Members { get; }
 
         public string IconUrl { get; }
 
-        public Guild(string id, string name, List<Role> roles, string? iconHash)
+        public Guild(string id, string name, IReadOnlyList<Role> roles, string? iconHash)
         {
             Id = id;
             Name = name;
@@ -36,12 +37,12 @@ namespace DiscordChatExporter.Core.Models
 
     public partial class Guild
     {
-        public static string GetUserColor(Guild guild, User user) => 
+        public static string GetUserColor(Guild guild, User user) =>
                 guild.Members.GetValueOrDefault(user.Id, null)?.Roles
                 ?.Select(r => guild.Roles
                             .Where(role => r == role.Id)
                             .FirstOrDefault()
-                )?.Where(r => r.Color != 0)?
+                )?.Where(r => r.Color != Color.Black)?
                 .Aggregate<Role, Role?>(null, (a, b) => (a?.Position ?? 0) > b.Position? a : b)?
                 .ColorAsHex ?? "";
         public static string GetUserNick(Guild guild, User user) => guild.Members.GetValueOrDefault(user.Id)?.Nick ?? user.Name;
@@ -53,6 +54,6 @@ namespace DiscordChatExporter.Core.Models
                 : "https://cdn.discordapp.com/embed/avatars/0.png";
         }
 
-        public static Guild DirectMessages { get; } = new Guild("@me", "Direct Messages", new List<Role>(), null);
+        public static Guild DirectMessages { get; } = new Guild("@me", "Direct Messages", Array.Empty<Role>(), null);
     }
 }

--- a/DiscordChatExporter.Core.Models/Guild.cs
+++ b/DiscordChatExporter.Core.Models/Guild.cs
@@ -41,7 +41,8 @@ namespace DiscordChatExporter.Core.Models
                 ?.Select(r => guild.Roles
                             .Where(role => r == role.Id)
                             .FirstOrDefault()
-                )?.FirstOrDefault()?
+                )?.Where(r => r.Color != 0)?
+                .Aggregate(Role.Everyone, (a, b) => a.Position > b.Position? a : b)?
                 .ColorAsHex ?? "#FFFFFF";
         public static string GetUserNick(Guild guild, User user) => guild.Members[user.Id]?.Nick ?? user.Name;
 

--- a/DiscordChatExporter.Core.Models/Guild.cs
+++ b/DiscordChatExporter.Core.Models/Guild.cs
@@ -43,7 +43,7 @@ namespace DiscordChatExporter.Core.Models
                             .FirstOrDefault()
                 )?.Where(r => r.Color != 0)?
                 .Aggregate(Role.Everyone, (a, b) => a.Position > b.Position? a : b)?
-                .ColorAsHex ?? "#FFFFFF";
+                .ColorAsHex ?? "";
         public static string GetUserNick(Guild guild, User user) => guild.Members[user.Id]?.Nick ?? user.Name;
 
         public static string GetIconUrl(string id, string? iconHash)

--- a/DiscordChatExporter.Core.Models/Member.cs
+++ b/DiscordChatExporter.Core.Models/Member.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DiscordChatExporter.Core.Models
+{
+    public class Member
+    {
+        public string UserId;
+        public string? Nick;
+
+        public string[] Roles { get; }
+
+        public Member(string userId, string? nick, string[] roles)
+        {
+            UserId = userId;
+            Nick = nick;
+            Roles = roles;
+        }
+    }
+}

--- a/DiscordChatExporter.Core.Models/Member.cs
+++ b/DiscordChatExporter.Core.Models/Member.cs
@@ -5,12 +5,12 @@ namespace DiscordChatExporter.Core.Models
 {
     public class Member
     {
-        public string UserId;
-        public string? Nick;
+        public string UserId { get; }
+        public string? Nick { get; }
 
-        public string[] Roles { get; }
+        public IReadOnlyList<string> Roles { get; }
 
-        public Member(string userId, string? nick, string[] roles)
+        public Member(string userId, string? nick, IReadOnlyList<string> roles)
         {
             UserId = userId;
             Nick = nick;

--- a/DiscordChatExporter.Core.Models/Role.cs
+++ b/DiscordChatExporter.Core.Models/Role.cs
@@ -29,11 +29,6 @@ namespace DiscordChatExporter.Core.Models
 
     public partial class Role
     {
-        private static Role? _everyone;
-        public static Role Everyone
-        {
-            get => _everyone ?? (_everyone = new Role("", "@everyone", 0, 0));
-        }
         public static Role CreateDeletedRole(string id) => new Role(id, "deleted-role", 0, -1);
     }
 }

--- a/DiscordChatExporter.Core.Models/Role.cs
+++ b/DiscordChatExporter.Core.Models/Role.cs
@@ -11,7 +11,7 @@ namespace DiscordChatExporter.Core.Models
 
         public int Color { get; }
 
-        public string ColorAsHex { get => "#"+Color.ToString("X6"); }
+        public string ColorAsHex { get => Color == 0? "" : "#"+Color.ToString("X6"); }
 
         public int Position { get; }
 
@@ -28,7 +28,7 @@ namespace DiscordChatExporter.Core.Models
 
     public partial class Role
     {
-        private static Role _everyone;
+        private static Role? _everyone;
         public static Role Everyone
         {
             get => _everyone ?? (_everyone = new Role("", "@everyone", 0, 0));

--- a/DiscordChatExporter.Core.Models/Role.cs
+++ b/DiscordChatExporter.Core.Models/Role.cs
@@ -1,4 +1,5 @@
-﻿namespace DiscordChatExporter.Core.Models
+﻿
+namespace DiscordChatExporter.Core.Models
 {
     // https://discordapp.com/developers/docs/topics/permissions#role-object
 
@@ -8,10 +9,18 @@
 
         public string Name { get; }
 
-        public Role(string id, string name)
+        public int Color { get; }
+
+        public string ColorAsHex { get => "#"+Color.ToString("X6"); }
+
+        public int Position { get; }
+
+        public Role(string id, string name, int color, int position)
         {
             Id = id;
             Name = name;
+            Color = color;
+            Position = position;
         }
 
         public override string ToString() => Name;
@@ -19,6 +28,6 @@
 
     public partial class Role
     {
-        public static Role CreateDeletedRole(string id) => new Role(id, "deleted-role");
+        public static Role CreateDeletedRole(string id) => new Role(id, "deleted-role", 0xffffff, -1);
     }
 }

--- a/DiscordChatExporter.Core.Models/Role.cs
+++ b/DiscordChatExporter.Core.Models/Role.cs
@@ -12,7 +12,7 @@ namespace DiscordChatExporter.Core.Models
         public int Color { get; }
 
         public string ColorAsHex { get => "#"+Color.ToString("X6"); }
-        public string ColorAsRgb { get => $"{Color>>8}, {(Color & 0xff00)>>4}, {Color & 0xff}"; }
+        public string ColorAsRgb { get => $"{Color>>16}, {(Color & 0xff00)>>8}, {Color & 0xff}"; }
 
         public int Position { get; }
 

--- a/DiscordChatExporter.Core.Models/Role.cs
+++ b/DiscordChatExporter.Core.Models/Role.cs
@@ -11,7 +11,8 @@ namespace DiscordChatExporter.Core.Models
 
         public int Color { get; }
 
-        public string ColorAsHex { get => Color == 0? "" : "#"+Color.ToString("X6"); }
+        public string ColorAsHex { get => "#"+Color.ToString("X6"); }
+        public string ColorAsRgb { get => $"{Color>>8}, {(Color & 0xff00)>>4}, {Color & 0xff}"; }
 
         public int Position { get; }
 

--- a/DiscordChatExporter.Core.Models/Role.cs
+++ b/DiscordChatExporter.Core.Models/Role.cs
@@ -28,6 +28,11 @@ namespace DiscordChatExporter.Core.Models
 
     public partial class Role
     {
+        private static Role _everyone;
+        public static Role Everyone
+        {
+            get => _everyone ?? (_everyone = new Role("", "@everyone", 0xffffff, 0));
+        }
         public static Role CreateDeletedRole(string id) => new Role(id, "deleted-role", 0xffffff, -1);
     }
 }

--- a/DiscordChatExporter.Core.Models/Role.cs
+++ b/DiscordChatExporter.Core.Models/Role.cs
@@ -31,8 +31,8 @@ namespace DiscordChatExporter.Core.Models
         private static Role _everyone;
         public static Role Everyone
         {
-            get => _everyone ?? (_everyone = new Role("", "@everyone", 0xffffff, 0));
+            get => _everyone ?? (_everyone = new Role("", "@everyone", 0, 0));
         }
-        public static Role CreateDeletedRole(string id) => new Role(id, "deleted-role", 0xffffff, -1);
+        public static Role CreateDeletedRole(string id) => new Role(id, "deleted-role", 0, -1);
     }
 }

--- a/DiscordChatExporter.Core.Models/Role.cs
+++ b/DiscordChatExporter.Core.Models/Role.cs
@@ -1,4 +1,6 @@
 ﻿
+using System.Drawing;
+
 namespace DiscordChatExporter.Core.Models
 {
     // https://discordapp.com/developers/docs/topics/permissions#role-object
@@ -9,14 +11,14 @@ namespace DiscordChatExporter.Core.Models
 
         public string Name { get; }
 
-        public int Color { get; }
+        public Color Color { get; }
 
-        public string ColorAsHex { get => "#"+Color.ToString("X6"); }
-        public string ColorAsRgb { get => $"{Color>>16}, {(Color & 0xff00)>>8}, {Color & 0xff}"; }
+        public string ColorAsHex => $"#{(Color.ToArgb() & 0xffffff):X6}";
+        public string ColorAsRgb => $"{Color.R}, {Color.G}, {Color.B}";
 
         public int Position { get; }
 
-        public Role(string id, string name, int color, int position)
+        public Role(string id, string name, Color color, int position)
         {
             Id = id;
             Name = name;
@@ -29,6 +31,6 @@ namespace DiscordChatExporter.Core.Models
 
     public partial class Role
     {
-        public static Role CreateDeletedRole(string id) => new Role(id, "deleted-role", 0, -1);
+        public static Role CreateDeletedRole(string id) => new Role(id, "deleted-role", Color.Black, -1);
     }
 }

--- a/DiscordChatExporter.Core.Rendering/Formatters/HtmlMessageWriter.cs
+++ b/DiscordChatExporter.Core.Rendering/Formatters/HtmlMessageWriter.cs
@@ -75,6 +75,10 @@ namespace DiscordChatExporter.Core.Rendering.Formatters
             scriptObject.Import("FormatMarkdown",
                 new Func<string, string>(m => HtmlRenderingLogic.FormatMarkdown(Context, m)));
 
+            scriptObject.Import("GetUserColor", new Func<Guild, User, string>(Guild.GetUserColor));
+            
+            scriptObject.Import("GetUserNick", new Func<Guild, User, string>(Guild.GetUserNick));
+
             // Push model
             templateContext.PushGlobal(scriptObject);
 

--- a/DiscordChatExporter.Core.Rendering/Logic/HtmlRenderingLogic.cs
+++ b/DiscordChatExporter.Core.Rendering/Logic/HtmlRenderingLogic.cs
@@ -115,7 +115,7 @@ namespace DiscordChatExporter.Core.Rendering.Logic
                     var role = context.MentionableRoles.FirstOrDefault(r => r.Id == mentionNode.Id) ??
                                Role.CreateDeletedRole(mentionNode.Id);
                     string style = "";
-                    if (role.Color != 0) style = $"style=\"color: {role.ColorAsHex}; background-color: rgba({role.ColorAsRgb}, 0.1);\"";
+                    if (role.Color != 0) style = $"style=\"color: {role.ColorAsHex}; background-color: rgba({role.ColorAsRgb}, 0.1); weight: 400;\"";
                     return $"<span class=\"mention\" {style}>@{HtmlEncode(role.Name)}</span>";
                 }
             }

--- a/DiscordChatExporter.Core.Rendering/Logic/HtmlRenderingLogic.cs
+++ b/DiscordChatExporter.Core.Rendering/Logic/HtmlRenderingLogic.cs
@@ -114,8 +114,9 @@ namespace DiscordChatExporter.Core.Rendering.Logic
                 {
                     var role = context.MentionableRoles.FirstOrDefault(r => r.Id == mentionNode.Id) ??
                                Role.CreateDeletedRole(mentionNode.Id);
-
-                    return $"<span class=\"mention\">@{HtmlEncode(role.Name)}</span>";
+                    string style = "";
+                    if (role.Color != 0) style = $"style=\"color: {role.ColorAsHex}; background-color: rgba({role.ColorAsRgb}, 0.1);\"";
+                    return $"<span class=\"mention\" {style}>@{HtmlEncode(role.Name)}</span>";
                 }
             }
 

--- a/DiscordChatExporter.Core.Rendering/Logic/HtmlRenderingLogic.cs
+++ b/DiscordChatExporter.Core.Rendering/Logic/HtmlRenderingLogic.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
@@ -115,7 +116,7 @@ namespace DiscordChatExporter.Core.Rendering.Logic
                     var role = context.MentionableRoles.FirstOrDefault(r => r.Id == mentionNode.Id) ??
                                Role.CreateDeletedRole(mentionNode.Id);
                     string style = "";
-                    if (role.Color != 0) style = $"style=\"color: {role.ColorAsHex}; background-color: rgba({role.ColorAsRgb}, 0.1); font-weight: 400;\"";
+                    if (role.Color != Color.Black) style = $"style=\"color: {role.ColorAsHex}; background-color: rgba({role.ColorAsRgb}, 0.1); font-weight: 400;\"";
                     return $"<span class=\"mention\" {style}>@{HtmlEncode(role.Name)}</span>";
                 }
             }

--- a/DiscordChatExporter.Core.Rendering/Logic/HtmlRenderingLogic.cs
+++ b/DiscordChatExporter.Core.Rendering/Logic/HtmlRenderingLogic.cs
@@ -115,7 +115,7 @@ namespace DiscordChatExporter.Core.Rendering.Logic
                     var role = context.MentionableRoles.FirstOrDefault(r => r.Id == mentionNode.Id) ??
                                Role.CreateDeletedRole(mentionNode.Id);
                     string style = "";
-                    if (role.Color != 0) style = $"style=\"color: {role.ColorAsHex}; background-color: rgba({role.ColorAsRgb}, 0.1); weight: 400;\"";
+                    if (role.Color != 0) style = $"style=\"color: {role.ColorAsHex}; background-color: rgba({role.ColorAsRgb}, 0.1); font-weight: 400;\"";
                     return $"<span class=\"mention\" {style}>@{HtmlEncode(role.Name)}</span>";
                 }
             }

--- a/DiscordChatExporter.Core.Rendering/Resources/HtmlMessageGroupTemplate.html
+++ b/DiscordChatExporter.Core.Rendering/Resources/HtmlMessageGroupTemplate.html
@@ -5,7 +5,7 @@
     </div>
     <div class="chatlog__messages">
         {{~ # Author name and timestamp ~}}
-        <span class="chatlog__author-name" title="{{ MessageGroup.Author.FullName | html.escape }}" data-user-id="{{ MessageGroup.Author.Id | html.escape }}">{{ MessageGroup.Author.Name | html.escape }}</span>
+    <span class="chatlog__author-name" title="{{ MessageGroup.Author.FullName | html.escape }}" data-user-id="{{ MessageGroup.Author.Id | html.escape }}" style="color: {{ GetUserColor Context.Guild MessageGroup.Author }}">{{ GetUserNick Context.Guild MessageGroup.Author | html.escape }}</span>
 
         {{~ # Bot tag ~}}
         {{~ if MessageGroup.Author.IsBot ~}}

--- a/DiscordChatExporter.Core.Services/DataService.Parsers.cs
+++ b/DiscordChatExporter.Core.Services/DataService.Parsers.cs
@@ -77,7 +77,7 @@ namespace DiscordChatExporter.Core.Services
             var color = json["color"]!.Value<int>();
             var position = json["position"]!.Value<int>();
 
-            return new Role(id, name, color, position);
+            return new Role(id, name, Color.FromArgb(color), position);
         }
 
         private Attachment ParseAttachment(JToken json)

--- a/DiscordChatExporter.Core.Services/DataService.Parsers.cs
+++ b/DiscordChatExporter.Core.Services/DataService.Parsers.cs
@@ -21,13 +21,23 @@ namespace DiscordChatExporter.Core.Services
             return new User(id, discriminator, name, avatarHash, isBot);
         }
 
+        private Member ParseMember(JToken json)
+        {
+            var userId = ParseUser(json["user"]!).Id;
+            var nick = json["nick"]?.Value<string>();
+            var roles = json["roles"]!.Select(jt => jt.Value<string>()).ToArray();
+
+            return new Member(userId, nick, roles);
+        }
+
         private Guild ParseGuild(JToken json)
         {
             var id = json["id"]!.Value<string>();
             var name = json["name"]!.Value<string>();
             var iconHash = json["icon"]!.Value<string>();
+            var roles = json["roles"]!.Select(ParseRole).ToList();
 
-            return new Guild(id, name, iconHash);
+            return new Guild(id, name, roles, iconHash);
         }
 
         private Channel ParseChannel(JToken json)
@@ -64,8 +74,10 @@ namespace DiscordChatExporter.Core.Services
         {
             var id = json["id"]!.Value<string>();
             var name = json["name"]!.Value<string>();
+            var color = json["color"]!.Value<int>();
+            var position = json["position"]!.Value<int>();
 
-            return new Role(id, name);
+            return new Role(id, name, color, position);
         }
 
         private Attachment ParseAttachment(JToken json)
@@ -193,7 +205,7 @@ namespace DiscordChatExporter.Core.Services
 
             // Get author
             var author = ParseUser(json["author"]!);
-
+            
             // Get attachments
             var attachments = (json["attachments"] ?? Enumerable.Empty<JToken>()).Select(ParseAttachment).ToArray();
 


### PR DESCRIPTION
The data included in the Guild Member object allowed me to implement colored names and nicknames in the HTML output.

I wasn't sure if JSON output should include either of these, so that's something that might still need to be done.

I had to refactor existing code in a couple important ways:

 - The only way to check if a user isn't a guild member without retrieving every guild member (which might require additional privileges) is to send the API request and check for a 404. Because anything other than 200 made the program throw an error, I had to add a "errorOnFail" bool to disable this functionality.

- I couldn't find a good place to save nickname and color since they depend on the guild and the user, so I had to add functions to the HTML message template to get these values.

Closes #153