### PR TITLE
Add option to use UTC instead of local time for timestamps

### DIFF
--- a/DiscordChatExporter.Core.Rendering/Formatters/HtmlMessageWriter.cs
+++ b/DiscordChatExporter.Core.Rendering/Formatters/HtmlMessageWriter.cs
@@ -70,7 +70,7 @@ namespace DiscordChatExporter.Core.Rendering.Formatters
 
             // Functions
             scriptObject.Import("FormatDate",
-                new Func<DateTimeOffset, string>(d => SharedRenderingLogic.FormatDate(d, Context.DateFormat)));
+                new Func<DateTimeOffset, string>(d => SharedRenderingLogic.FormatDate(d, Context.DateFormat, Context.IsUseUtcEnabled)));
 
             scriptObject.Import("FormatMarkdown",
                 new Func<string, string>(m => HtmlRenderingLogic.FormatMarkdown(Context, m)));

--- a/DiscordChatExporter.Core.Rendering/Logic/CsvRenderingLogic.cs
+++ b/DiscordChatExporter.Core.Rendering/Logic/CsvRenderingLogic.cs
@@ -28,7 +28,7 @@ namespace DiscordChatExporter.Core.Rendering.Logic
             buffer
                 .Append(EncodeValue(message.Author.Id)).Append(',')
                 .Append(EncodeValue(message.Author.FullName)).Append(',')
-                .Append(EncodeValue(FormatDate(message.Timestamp, context.DateFormat))).Append(',')
+                .Append(EncodeValue(FormatDate(message.Timestamp, context.DateFormat, context.IsUseUtcEnabled))).Append(',')
                 .Append(EncodeValue(FormatMarkdown(context, message.Content ?? ""))).Append(',')
                 .Append(EncodeValue(message.Attachments.Select(a => a.Url).JoinToString(","))).Append(',')
                 .Append(EncodeValue(message.Reactions.Select(r => $"{r.Emoji.Name} ({r.Count})").JoinToString(",")));

--- a/DiscordChatExporter.Core.Rendering/Logic/PlainTextRenderingLogic.cs
+++ b/DiscordChatExporter.Core.Rendering/Logic/PlainTextRenderingLogic.cs
@@ -26,10 +26,10 @@ namespace DiscordChatExporter.Core.Rendering.Logic
                 buffer.AppendLine($"Topic: {context.Channel.Topic}");
 
             if (context.After != null)
-                buffer.AppendLine($"After: {FormatDate(context.After.Value, context.DateFormat)}");
+                buffer.AppendLine($"After: {FormatDate(context.After.Value, context.DateFormat, context.IsUseUtcEnabled)}");
 
             if (context.Before != null)
-                buffer.AppendLine($"Before: {FormatDate(context.Before.Value, context.DateFormat)}");
+                buffer.AppendLine($"Before: {FormatDate(context.Before.Value, context.DateFormat, context.IsUseUtcEnabled)}");
 
             buffer.Append('=', 62).AppendLine();
 
@@ -111,7 +111,7 @@ namespace DiscordChatExporter.Core.Rendering.Logic
 
             // Timestamp & author
             buffer
-                .Append($"[{FormatDate(message.Timestamp, context.DateFormat)}]")
+                .Append($"[{FormatDate(message.Timestamp, context.DateFormat, context.IsUseUtcEnabled)}]")
                 .Append(' ')
                 .Append($"{message.Author.FullName}");
 

--- a/DiscordChatExporter.Core.Rendering/Logic/SharedRenderingLogic.cs
+++ b/DiscordChatExporter.Core.Rendering/Logic/SharedRenderingLogic.cs
@@ -5,7 +5,7 @@ namespace DiscordChatExporter.Core.Rendering.Logic
 {
     public static class SharedRenderingLogic
     {
-        public static string FormatDate(DateTimeOffset date, string dateFormat) =>
-            date.ToLocalTime().ToString(dateFormat, CultureInfo.InvariantCulture);
+        public static string FormatDate(DateTimeOffset date, string dateFormat, bool isUseUtcEnabled) =>
+            (isUseUtcEnabled ? date.ToUniversalTime() : date.ToLocalTime()).ToString(dateFormat, CultureInfo.InvariantCulture);
     }
 }

--- a/DiscordChatExporter.Core.Rendering/RenderContext.cs
+++ b/DiscordChatExporter.Core.Rendering/RenderContext.cs
@@ -16,13 +16,15 @@ namespace DiscordChatExporter.Core.Rendering
 
         public string DateFormat { get; }
 
+        public bool IsUseUtcEnabled { get; }
+
         public IReadOnlyCollection<User> MentionableUsers { get; }
 
         public IReadOnlyCollection<Channel> MentionableChannels { get; }
 
         public IReadOnlyCollection<Role> MentionableRoles { get; }
 
-        public RenderContext(Guild guild, Channel channel, DateTimeOffset? after, DateTimeOffset? before, string dateFormat,
+        public RenderContext(Guild guild, Channel channel, DateTimeOffset? after, DateTimeOffset? before, string dateFormat, bool isUseUtcEnabled,
             IReadOnlyCollection<User> mentionableUsers, IReadOnlyCollection<Channel> mentionableChannels, IReadOnlyCollection<Role> mentionableRoles)
         {
             Guild = guild;
@@ -30,6 +32,7 @@ namespace DiscordChatExporter.Core.Rendering
             After = after;
             Before = before;
             DateFormat = dateFormat;
+            IsUseUtcEnabled = isUseUtcEnabled;
             MentionableUsers = mentionableUsers;
             MentionableChannels = mentionableChannels;
             MentionableRoles = mentionableRoles;

--- a/DiscordChatExporter.Core.Services/ExportService.cs
+++ b/DiscordChatExporter.Core.Services/ExportService.cs
@@ -38,7 +38,7 @@ namespace DiscordChatExporter.Core.Services
 
             var context = new RenderContext
             (
-                guild, channel, after, before, _settingsService.DateFormat,
+                guild, channel, after, before, _settingsService.DateFormat, _settingsService.IsUseUtcEnabled,
                 mentionableUsers, mentionableChannels, mentionableRoles
             );
 

--- a/DiscordChatExporter.Core.Services/SettingsService.cs
+++ b/DiscordChatExporter.Core.Services/SettingsService.cs
@@ -7,6 +7,8 @@ namespace DiscordChatExporter.Core.Services
     {
         public string DateFormat { get; set; } = "dd-MMM-yy hh:mm tt";
 
+        public bool IsUseUtcEnabled { get; set; } = false;
+
         public bool IsAutoUpdateEnabled { get; set; } = true;
 
         public bool IsTokenPersisted { get; set; } = true;

--- a/DiscordChatExporter.Gui/ViewModels/Dialogs/SettingsViewModel.cs
+++ b/DiscordChatExporter.Gui/ViewModels/Dialogs/SettingsViewModel.cs
@@ -14,6 +14,12 @@ namespace DiscordChatExporter.Gui.ViewModels.Dialogs
             set => _settingsService.DateFormat = value;
         }
 
+        public bool IsUseUtcEnabled
+        {
+            get => _settingsService.IsUseUtcEnabled;
+            set => _settingsService.IsUseUtcEnabled = value;
+        }
+
         public bool IsAutoUpdateEnabled
         {
             get => _settingsService.IsAutoUpdateEnabled;

--- a/DiscordChatExporter.Gui/Views/Dialogs/SettingsView.xaml
+++ b/DiscordChatExporter.Gui/Views/Dialogs/SettingsView.xaml
@@ -26,6 +26,21 @@
             Text="{Binding DateFormat}"
             ToolTip="Format used when rendering dates (refer to .NET date format)" />
 
+        <!--  UTC / local time  -->
+        <DockPanel
+            Background="Transparent"
+            LastChildFill="False"
+            ToolTip="Use UTC instead of local time for message timestamps">
+            <TextBlock
+                Margin="16,8"
+                DockPanel.Dock="Left"
+                Text="Use UTC instead of local time" />
+            <ToggleButton
+                Margin="16,8"
+                DockPanel.Dock="Right"
+                IsChecked="{Binding IsUseUtcEnabled}" />
+        </DockPanel>
+
         <!--  Auto-updates  -->
         <DockPanel
             Background="Transparent"


### PR DESCRIPTION
This adds an option in the settings menu to use UTC instead of the local time for message timestamps (defaults to false).

(This does not affect the JSON export format. However, since time zone information is preserved in that format, whoever consumes it can convert into their preferred time zone anyway.)