### PR TITLE
[CLI] Add command to export all channels across all guilds

### DIFF
--- a/DiscordChatExporter.Cli/Commands/ExportAllCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/ExportAllCommand.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using CliFx;
 using CliFx.Attributes;
 using DiscordChatExporter.Cli.Commands.Base;
+using DiscordChatExporter.Domain.Discord.Models;
 using DiscordChatExporter.Domain.Utilities;
 
 namespace DiscordChatExporter.Cli.Commands

--- a/DiscordChatExporter.Cli/Commands/ExportAllCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/ExportAllCommand.cs
@@ -10,10 +10,11 @@ namespace DiscordChatExporter.Cli.Commands
     [Command("exportall", Description = "Export all direct messages and all channels within all guilds.")]
     public class ExportAllGuildsCommand : ExportMultipleCommandBase
     {
+        [CommandOption("exclude-dm", 'e', Description = "If this flag is present, direct messages will not be exported.")]
+        public bool ExcludeDMs { get; set; }
+        
         public override async ValueTask ExecuteAsync(IConsole console)
         {
-            [CommandOption("exclude-dm", 'e', Description = "If this flag is present, direct messages will not be exported.")]
-            public bool ExcludeDMs { get; set; }
 
             if(!ExcludeDMs){
                 var dmChannels = await GetDiscordClient().GetGuildChannelsAsync(Guild.DirectMessages.Id);

--- a/DiscordChatExporter.Cli/Commands/ExportAllCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/ExportAllCommand.cs
@@ -7,11 +7,19 @@ using DiscordChatExporter.Domain.Utilities;
 
 namespace DiscordChatExporter.Cli.Commands
 {
-    [Command("exportallguilds", Description = "Export all channels within specified all guilds.")]
+    [Command("exportall", Description = "Export all direct messages and all channels within all guilds.")]
     public class ExportAllGuildsCommand : ExportMultipleCommandBase
     {
         public override async ValueTask ExecuteAsync(IConsole console)
         {
+            [CommandOption("exclude-dm", 'e', Description = "If this flag is present, direct messages will not be exported.")]
+            public bool ExcludeDMs { get; set; }
+
+            if(!ExcludeDMs){
+                var dmChannels = await GetDiscordClient().GetGuildChannelsAsync(Guild.DirectMessages.Id);
+                await ExportMultipleAsync(console, dmChannels);
+            }
+
             var guilds = await GetDiscordClient().GetUserGuildsAsync();
             foreach (var guild in guilds.OrderBy(g => g.Name))
             {

--- a/DiscordChatExporter.Cli/Commands/ExportAllCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/ExportAllCommand.cs
@@ -8,7 +8,7 @@ using DiscordChatExporter.Domain.Utilities;
 namespace DiscordChatExporter.Cli.Commands
 {
     [Command("exportall", Description = "Export all direct messages and all channels within all guilds.")]
-    public class ExportAllGuildsCommand : ExportMultipleCommandBase
+    public class ExportAllCommand : ExportMultipleCommandBase
     {
         [CommandOption("exclude-dm", 'e', Description = "If this flag is present, direct messages will not be exported.")]
         public bool ExcludeDMs { get; set; }

--- a/DiscordChatExporter.Cli/Commands/ExportAllGuildsCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/ExportAllGuildsCommand.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using System.Threading.Tasks;
+using CliFx;
+using CliFx.Attributes;
+using DiscordChatExporter.Cli.Commands.Base;
+using DiscordChatExporter.Domain.Utilities;
+
+namespace DiscordChatExporter.Cli.Commands
+{
+    [Command("guilds", Description = "Get the list of accessible guilds.")]
+    public class GetGuildsCommand : TokenCommandBase
+    {
+        public override async ValueTask ExecuteAsync(IConsole console)
+        {
+            var guilds = await GetDiscordClient().GetUserGuildsAsync();
+            foreach (var guild in guilds.OrderBy(g => g.Name))
+            {
+                var guildChannels = await GetDiscordClient().GetGuildChannelsAsync(guild.Id);
+                await ExportMultipleAsync(console, guildChannels);
+            }
+        }
+    }
+}

--- a/DiscordChatExporter.Cli/Commands/ExportAllGuildsCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/ExportAllGuildsCommand.cs
@@ -7,8 +7,8 @@ using DiscordChatExporter.Domain.Utilities;
 
 namespace DiscordChatExporter.Cli.Commands
 {
-    [Command("guilds", Description = "Get the list of accessible guilds.")]
-    public class GetGuildsCommand : TokenCommandBase
+    [Command("exportallguilds", Description = "Export all channels within specified all guilds.")]
+    public class ExportAllGuildsCommand : TokenCommandBase
     {
         public override async ValueTask ExecuteAsync(IConsole console)
         {

--- a/DiscordChatExporter.Cli/Commands/ExportAllGuildsCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/ExportAllGuildsCommand.cs
@@ -8,7 +8,7 @@ using DiscordChatExporter.Domain.Utilities;
 namespace DiscordChatExporter.Cli.Commands
 {
     [Command("exportallguilds", Description = "Export all channels within specified all guilds.")]
-    public class ExportAllGuildsCommand : TokenCommandBase
+    public class ExportAllGuildsCommand : ExportMultipleCommandBase
     {
         public override async ValueTask ExecuteAsync(IConsole console)
         {


### PR DESCRIPTION
Add a new command to export all Guilds. I don't really write C#, so I just combined the internal logic of GetGuildsCommand.cs and ExportGuildCommand.cs in a way that hopefully works! This addresses issues #274 and #363.

Presumably the syntax for calling this command will have to be added elsewhere, though I imagine it isn't hard.

Closes #274 