### PR TITLE
[GUI] Add dark theme

### DIFF
--- a/DiscordChatExporter.Gui/App.xaml
+++ b/DiscordChatExporter.Gui/App.xaml
@@ -21,7 +21,6 @@
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
-
             <!--  Styles  -->
             <Style x:Key="MaterialDesignRoot" TargetType="{x:Type Control}">
                 <Setter Property="FontFamily" Value="{DynamicResource MaterialDesignFont}" />

--- a/DiscordChatExporter.Gui/App.xaml
+++ b/DiscordChatExporter.Gui/App.xaml
@@ -15,9 +15,9 @@
             <!--  Merged dictionaries  -->
             <ResourceDictionary.MergedDictionaries>
                 <materialDesign:BundledTheme
-                    BaseTheme="Dark"
-                    PrimaryColor="LightBlue"
-                    SecondaryColor="LightBlue" />
+                    BaseTheme="Light"
+                    PrimaryColor="Blue"
+                    SecondaryColor="Blue" />
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
             </ResourceDictionary.MergedDictionaries>
 

--- a/DiscordChatExporter.Gui/App.xaml
+++ b/DiscordChatExporter.Gui/App.xaml
@@ -14,68 +14,13 @@
 
             <!--  Merged dictionaries  -->
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />
+                <materialDesign:BundledTheme
+                    BaseTheme="Dark"
+                    PrimaryColor="LightBlue"
+                    SecondaryColor="LightBlue" />
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
-            <!--  Colors  -->
-            <Color x:Key="PrimaryColor">#343838</Color>
-            <Color x:Key="PrimaryLightColor">#5E6262</Color>
-            <Color x:Key="PrimaryDarkColor">#0D1212</Color>
-            <Color x:Key="AccentColor">#F9A825</Color>
-            <Color x:Key="AccentDarkColor">#C17900</Color>
-            <Color x:Key="TextColor">#000000</Color>
-            <Color x:Key="InverseTextColor">#FFFFFF</Color>
-
-            <SolidColorBrush x:Key="PrimaryHueLightBrush" Color="{DynamicResource PrimaryLightColor}" />
-            <SolidColorBrush x:Key="PrimaryHueLightForegroundBrush" Color="{DynamicResource InverseTextColor}" />
-            <SolidColorBrush x:Key="PrimaryHueMidBrush" Color="{DynamicResource PrimaryColor}" />
-            <SolidColorBrush x:Key="PrimaryHueMidForegroundBrush" Color="{DynamicResource InverseTextColor}" />
-            <SolidColorBrush x:Key="PrimaryHueDarkBrush" Color="{DynamicResource PrimaryDarkColor}" />
-            <SolidColorBrush x:Key="PrimaryHueDarkForegroundBrush" Color="{DynamicResource InverseTextColor}" />
-            <SolidColorBrush x:Key="SecondaryAccentBrush" Color="{DynamicResource AccentColor}" />
-            <SolidColorBrush x:Key="SecondaryAccentForegroundBrush" Color="{DynamicResource TextColor}" />
-
-            <SolidColorBrush
-                x:Key="PrimaryTextBrush"
-                Opacity="0.87"
-                Color="{DynamicResource TextColor}" />
-            <SolidColorBrush
-                x:Key="SecondaryTextBrush"
-                Opacity="0.64"
-                Color="{DynamicResource TextColor}" />
-            <SolidColorBrush
-                x:Key="DimTextBrush"
-                Opacity="0.45"
-                Color="{DynamicResource TextColor}" />
-            <SolidColorBrush
-                x:Key="PrimaryInverseTextBrush"
-                Opacity="1"
-                Color="{DynamicResource InverseTextColor}" />
-            <SolidColorBrush
-                x:Key="SecondaryInverseTextBrush"
-                Opacity="0.7"
-                Color="{DynamicResource InverseTextColor}" />
-            <SolidColorBrush
-                x:Key="DimInverseTextBrush"
-                Opacity="0.52"
-                Color="{DynamicResource InverseTextColor}" />
-            <SolidColorBrush
-                x:Key="AccentTextBrush"
-                Opacity="1"
-                Color="{DynamicResource AccentColor}" />
-            <SolidColorBrush
-                x:Key="AccentDarkTextBrush"
-                Opacity="1"
-                Color="{DynamicResource AccentDarkColor}" />
-            <SolidColorBrush
-                x:Key="DividerBrush"
-                Opacity="0.12"
-                Color="{DynamicResource TextColor}" />
-            <SolidColorBrush
-                x:Key="InverseDividerBrush"
-                Opacity="0.12"
-                Color="{DynamicResource InverseTextColor}" />
 
             <!--  Styles  -->
             <Style x:Key="MaterialDesignRoot" TargetType="{x:Type Control}">
@@ -84,7 +29,7 @@
                 <Setter Property="SnapsToDevicePixels" Value="True" />
                 <Setter Property="TextElement.FontSize" Value="13" />
                 <Setter Property="TextElement.FontWeight" Value="Regular" />
-                <Setter Property="TextElement.Foreground" Value="{DynamicResource SecondaryTextBrush}" />
+                <Setter Property="TextElement.Foreground" Value="{DynamicResource MaterialDesignBody}" />
                 <Setter Property="TextOptions.TextFormattingMode" Value="Ideal" />
                 <Setter Property="TextOptions.TextRenderingMode" Value="Auto" />
                 <Setter Property="UseLayoutRounding" Value="True" />
@@ -100,21 +45,13 @@
                 <Setter Property="Minimum" Value="0" />
             </Style>
 
-            <Style BasedOn="{StaticResource MaterialDesignTextBox}" TargetType="{x:Type TextBox}">
-                <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
-            </Style>
+            <Style BasedOn="{StaticResource MaterialDesignTextBox}" TargetType="{x:Type TextBox}" />
 
-            <Style BasedOn="{StaticResource MaterialDesignComboBox}" TargetType="{x:Type ComboBox}">
-                <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
-            </Style>
+            <Style BasedOn="{StaticResource MaterialDesignComboBox}" TargetType="{x:Type ComboBox}" />
 
-            <Style BasedOn="{StaticResource MaterialDesignDatePicker}" TargetType="{x:Type DatePicker}">
-                <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
-            </Style>
+            <Style BasedOn="{StaticResource MaterialDesignDatePicker}" TargetType="{x:Type DatePicker}" />
 
-            <Style BasedOn="{StaticResource MaterialDesignTimePicker}" TargetType="{x:Type materialDesign:TimePicker}">
-                <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
-            </Style>
+            <Style BasedOn="{StaticResource MaterialDesignTimePicker}" TargetType="{x:Type materialDesign:TimePicker}" />
 
             <Style
                 x:Key="MaterialDesignFlatDarkButton"

--- a/DiscordChatExporter.Gui/App.xaml
+++ b/DiscordChatExporter.Gui/App.xaml
@@ -38,6 +38,7 @@
 
             <Style BasedOn="{StaticResource MaterialDesignLinearProgressBar}" TargetType="{x:Type ProgressBar}">
                 <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="Background" Value="Transparent" />
                 <Setter Property="Foreground" Value="{DynamicResource SecondaryAccentBrush}" />
                 <Setter Property="Height" Value="2" />
                 <Setter Property="Maximum" Value="1" />

--- a/DiscordChatExporter.Gui/App.xaml.cs
+++ b/DiscordChatExporter.Gui/App.xaml.cs
@@ -15,15 +15,5 @@ namespace DiscordChatExporter.Gui
         public static Version Version => Assembly.GetName().Version!;
 
         public static string VersionString => Version.ToString(3);
-        public void SetTheme(Theme theme)
-        {
-            var paletteHelper = new PaletteHelper();
-            var mdTheme = paletteHelper.GetTheme();
-            mdTheme.SetBaseTheme(theme.BaseTheme);
-            mdTheme.SetPrimaryColor(theme.PrimaryColor);
-            mdTheme.SetSecondaryColor(theme.SecondaryColor);
-
-            paletteHelper.SetTheme(mdTheme);
-        }
     }
 }

--- a/DiscordChatExporter.Gui/App.xaml.cs
+++ b/DiscordChatExporter.Gui/App.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using MaterialDesignThemes.Wpf;
 
 namespace DiscordChatExporter.Gui
 {
@@ -12,5 +13,12 @@ namespace DiscordChatExporter.Gui
         public static Version Version => Assembly.GetName().Version!;
 
         public static string VersionString => Version.ToString(3);
+        public void setBaseTheme(IBaseTheme baseTheme)
+        {
+            var paletteHelper = new PaletteHelper();
+            var theme = paletteHelper.GetTheme();
+            theme.SetBaseTheme(baseTheme);
+            paletteHelper.SetTheme(theme);
+        }
     }
 }

--- a/DiscordChatExporter.Gui/App.xaml.cs
+++ b/DiscordChatExporter.Gui/App.xaml.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Reflection;
+using System.Windows.Media;
+using MaterialDesignColors;
 using MaterialDesignThemes.Wpf;
 
 namespace DiscordChatExporter.Gui
@@ -13,12 +15,15 @@ namespace DiscordChatExporter.Gui
         public static Version Version => Assembly.GetName().Version!;
 
         public static string VersionString => Version.ToString(3);
-        public void setBaseTheme(IBaseTheme baseTheme)
+        public void setTheme(Theme theme)
         {
             var paletteHelper = new PaletteHelper();
-            var theme = paletteHelper.GetTheme();
-            theme.SetBaseTheme(baseTheme);
-            paletteHelper.SetTheme(theme);
+            var mdTheme = paletteHelper.GetTheme();
+            mdTheme.SetBaseTheme(theme.baseTheme);
+            mdTheme.SetPrimaryColor(theme.primaryColor);
+            mdTheme.SetSecondaryColor(theme.secondaryColor);
+
+            paletteHelper.SetTheme(mdTheme);
         }
     }
 }

--- a/DiscordChatExporter.Gui/App.xaml.cs
+++ b/DiscordChatExporter.Gui/App.xaml.cs
@@ -15,13 +15,13 @@ namespace DiscordChatExporter.Gui
         public static Version Version => Assembly.GetName().Version!;
 
         public static string VersionString => Version.ToString(3);
-        public void setTheme(Theme theme)
+        public void SetTheme(Theme theme)
         {
             var paletteHelper = new PaletteHelper();
             var mdTheme = paletteHelper.GetTheme();
-            mdTheme.SetBaseTheme(theme.baseTheme);
-            mdTheme.SetPrimaryColor(theme.primaryColor);
-            mdTheme.SetSecondaryColor(theme.secondaryColor);
+            mdTheme.SetBaseTheme(theme.BaseTheme);
+            mdTheme.SetPrimaryColor(theme.PrimaryColor);
+            mdTheme.SetSecondaryColor(theme.SecondaryColor);
 
             paletteHelper.SetTheme(mdTheme);
         }

--- a/DiscordChatExporter.Gui/App.xaml.cs
+++ b/DiscordChatExporter.Gui/App.xaml.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Reflection;
-using System.Windows.Media;
-using MaterialDesignColors;
-using MaterialDesignThemes.Wpf;
 
 namespace DiscordChatExporter.Gui
 {

--- a/DiscordChatExporter.Gui/Services/SettingsService.cs
+++ b/DiscordChatExporter.Gui/Services/SettingsService.cs
@@ -12,6 +12,8 @@ namespace DiscordChatExporter.Gui.Services
 
         public bool IsTokenPersisted { get; set; } = true;
 
+        public bool IsDarkThemeEnabled { get; set; } = false;
+
         public int ParallelLimit { get; set; } = 1;
 
         public AuthToken? LastToken { get; set; }

--- a/DiscordChatExporter.Gui/Theme.cs
+++ b/DiscordChatExporter.Gui/Theme.cs
@@ -11,7 +11,17 @@ namespace DiscordChatExporter.Gui
     public sealed class Theme
     {
         public static Theme Light { get; } = new Theme(new MaterialDesignLightTheme(), HexToColor.convert("#343838"), HexToColor.convert("#F9A825"));
-        public static Theme Dark { get; } = new Theme(new MaterialDesignDarkTheme(), HexToColor.convert("#cbc7c7"), HexToColor.convert("#F9A825"));
+        public static Theme Dark { get; } = new Theme(new MaterialDesignDarkTheme(), HexToColor.convert("#03a9f4"), HexToColor.convert("#F9A825"));
+        public static void SetAppTheme(Theme theme)
+        {
+            var paletteHelper = new PaletteHelper();
+            var mdTheme = paletteHelper.GetTheme();
+            mdTheme.SetBaseTheme(theme.BaseTheme);
+            mdTheme.SetPrimaryColor(theme.PrimaryColor);
+            mdTheme.SetSecondaryColor(theme.SecondaryColor);
+
+            paletteHelper.SetTheme(mdTheme);
+        }
 
         public Theme(IBaseTheme baseTheme, Color primaryColor, Color secondaryColor)
         {

--- a/DiscordChatExporter.Gui/Theme.cs
+++ b/DiscordChatExporter.Gui/Theme.cs
@@ -12,16 +12,17 @@ namespace DiscordChatExporter.Gui
     {
         public static Theme Light { get; } = new Theme(new MaterialDesignLightTheme(), HexToColor.convert("#343838"), HexToColor.convert("#F9A825"));
         public static Theme Dark { get; } = new Theme(new MaterialDesignDarkTheme(), HexToColor.convert("#cbc7c7"), HexToColor.convert("#F9A825"));
-        private Theme(IBaseTheme baseTheme, Color primaryColor, Color secondaryColor)
+
+        public Theme(IBaseTheme baseTheme, Color primaryColor, Color secondaryColor)
         {
-            this.baseTheme = baseTheme;
-            this.primaryColor = primaryColor;
-            this.secondaryColor = secondaryColor;
+            BaseTheme = baseTheme;
+            PrimaryColor = primaryColor;
+            SecondaryColor = secondaryColor;
         }
 
-        public IBaseTheme baseTheme { get; }
-        public Color primaryColor { get; }
-        public Color secondaryColor { get; }
+        public IBaseTheme BaseTheme { get; }
+        public Color PrimaryColor { get; }
+        public Color SecondaryColor { get; }
 
         class HexToColor
         {

--- a/DiscordChatExporter.Gui/Theme.cs
+++ b/DiscordChatExporter.Gui/Theme.cs
@@ -11,7 +11,7 @@ namespace DiscordChatExporter.Gui
     public sealed class Theme
     {
         public static Theme Light { get; } = new Theme(new MaterialDesignLightTheme(), HexToColor.convert("#343838"), HexToColor.convert("#F9A825"));
-        public static Theme Dark { get; } = new Theme(new MaterialDesignDarkTheme(), HexToColor.convert("#2196f3"), HexToColor.convert("#F9A825"));
+        public static Theme Dark { get; } = new Theme(new MaterialDesignDarkTheme(), HexToColor.convert("#cbc7c7"), HexToColor.convert("#F9A825"));
         private Theme(IBaseTheme baseTheme, Color primaryColor, Color secondaryColor)
         {
             this.baseTheme = baseTheme;

--- a/DiscordChatExporter.Gui/Theme.cs
+++ b/DiscordChatExporter.Gui/Theme.cs
@@ -1,26 +1,23 @@
-﻿using MaterialDesignColors;
-using MaterialDesignColors.Recommended;
-using MaterialDesignThemes.Wpf;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using MaterialDesignThemes.Wpf;
 using System.Windows.Media;
 
 namespace DiscordChatExporter.Gui
 {
     public sealed class Theme
     {
-        public static Theme Light { get; } = new Theme(new MaterialDesignLightTheme(), HexToColor.convert("#343838"), HexToColor.convert("#F9A825"));
-        public static Theme Dark { get; } = new Theme(new MaterialDesignDarkTheme(), HexToColor.convert("#03a9f4"), HexToColor.convert("#F9A825"));
-        public static void SetAppTheme(Theme theme)
+        public static Theme Light { get; } = new Theme(new MaterialDesignLightTheme(), HexToColor.Convert("#343838"), HexToColor.Convert("#F9A825"));
+        public static Theme Dark { get; } = new Theme(new MaterialDesignDarkTheme(), HexToColor.Convert("#E8E8E8"), HexToColor.Convert("#F9A825"));
+
+        public static void SetCurrent(Theme theme)
         {
             var paletteHelper = new PaletteHelper();
-            var mdTheme = paletteHelper.GetTheme();
-            mdTheme.SetBaseTheme(theme.BaseTheme);
-            mdTheme.SetPrimaryColor(theme.PrimaryColor);
-            mdTheme.SetSecondaryColor(theme.SecondaryColor);
 
-            paletteHelper.SetTheme(mdTheme);
+            var materialTheme = paletteHelper.GetTheme();
+            materialTheme.SetBaseTheme(theme.BaseTheme);
+            materialTheme.SetPrimaryColor(theme.PrimaryColor);
+            materialTheme.SetSecondaryColor(theme.SecondaryColor);
+
+            paletteHelper.SetTheme(materialTheme);
         }
 
         public Theme(IBaseTheme baseTheme, Color primaryColor, Color secondaryColor)
@@ -36,7 +33,7 @@ namespace DiscordChatExporter.Gui
 
         class HexToColor
         {
-            public static Color convert(string hex)
+            public static Color Convert(string hex)
             {
                 return (Color)ColorConverter.ConvertFromString(hex);
             }

--- a/DiscordChatExporter.Gui/Theme.cs
+++ b/DiscordChatExporter.Gui/Theme.cs
@@ -1,0 +1,34 @@
+﻿using MaterialDesignColors;
+using MaterialDesignColors.Recommended;
+using MaterialDesignThemes.Wpf;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows.Media;
+
+namespace DiscordChatExporter.Gui
+{
+    public sealed class Theme
+    {
+        public static Theme Light { get; } = new Theme(new MaterialDesignLightTheme(), HexToColor.convert("#343838"), HexToColor.convert("#F9A825"));
+        public static Theme Dark { get; } = new Theme(new MaterialDesignDarkTheme(), HexToColor.convert("#2196f3"), HexToColor.convert("#F9A825"));
+        private Theme(IBaseTheme baseTheme, Color primaryColor, Color secondaryColor)
+        {
+            this.baseTheme = baseTheme;
+            this.primaryColor = primaryColor;
+            this.secondaryColor = secondaryColor;
+        }
+
+        public IBaseTheme baseTheme { get; }
+        public Color primaryColor { get; }
+        public Color secondaryColor { get; }
+
+        class HexToColor
+        {
+            public static Color convert(string hex)
+            {
+                return (Color)ColorConverter.ConvertFromString(hex);
+            }
+        }
+    }
+}

--- a/DiscordChatExporter.Gui/ViewModels/Dialogs/SettingsViewModel.cs
+++ b/DiscordChatExporter.Gui/ViewModels/Dialogs/SettingsViewModel.cs
@@ -26,6 +26,12 @@ namespace DiscordChatExporter.Gui.ViewModels.Dialogs
             set => _settingsService.IsTokenPersisted = value;
         }
 
+        public bool IsDarkThemeEnabled
+        {
+            get => _settingsService.IsDarkThemeEnabled;
+            set => _settingsService.IsDarkThemeEnabled = value;
+        }
+
         public int ParallelLimit
         {
             get => _settingsService.ParallelLimit;

--- a/DiscordChatExporter.Gui/ViewModels/RootViewModel.cs
+++ b/DiscordChatExporter.Gui/ViewModels/RootViewModel.cs
@@ -109,7 +109,7 @@ namespace DiscordChatExporter.Gui.ViewModels
             }
             if (_settingsService.IsDarkThemeEnabled != null)
             {
-                ((App)System.Windows.Application.Current).setBaseTheme(_settingsService.IsDarkThemeEnabled ? Theme.Dark : Theme.Light);
+                ((App)System.Windows.Application.Current).setTheme(_settingsService.IsDarkThemeEnabled ? Theme.Dark : Theme.Light);
             }
 
             await HandleAutoUpdateAsync();

--- a/DiscordChatExporter.Gui/ViewModels/RootViewModel.cs
+++ b/DiscordChatExporter.Gui/ViewModels/RootViewModel.cs
@@ -107,10 +107,8 @@ namespace DiscordChatExporter.Gui.ViewModels
                 IsBotToken = _settingsService.LastToken.Type == AuthTokenType.Bot;
                 TokenValue = _settingsService.LastToken.Value;
             }
-            if (_settingsService.IsDarkThemeEnabled != null)
-            {
-                ((App)System.Windows.Application.Current).setTheme(_settingsService.IsDarkThemeEnabled ? Theme.Dark : Theme.Light);
-            }
+            
+            ((App)System.Windows.Application.Current).setTheme(_settingsService.IsDarkThemeEnabled ? Theme.Dark : Theme.Light);
 
             await HandleAutoUpdateAsync();
         }

--- a/DiscordChatExporter.Gui/ViewModels/RootViewModel.cs
+++ b/DiscordChatExporter.Gui/ViewModels/RootViewModel.cs
@@ -108,7 +108,7 @@ namespace DiscordChatExporter.Gui.ViewModels
                 TokenValue = _settingsService.LastToken.Value;
             }
             
-            Theme.SetAppTheme(_settingsService.IsDarkThemeEnabled ? Theme.Dark : Theme.Light);
+            Theme.SetCurrent(_settingsService.IsDarkThemeEnabled ? Theme.Dark : Theme.Light);
 
             await HandleAutoUpdateAsync();
         }

--- a/DiscordChatExporter.Gui/ViewModels/RootViewModel.cs
+++ b/DiscordChatExporter.Gui/ViewModels/RootViewModel.cs
@@ -107,6 +107,10 @@ namespace DiscordChatExporter.Gui.ViewModels
                 IsBotToken = _settingsService.LastToken.Type == AuthTokenType.Bot;
                 TokenValue = _settingsService.LastToken.Value;
             }
+            if (_settingsService.IsDarkThemeEnabled != null)
+            {
+                ((App)System.Windows.Application.Current).setBaseTheme(_settingsService.IsDarkThemeEnabled ? Theme.Dark : Theme.Light);
+            }
 
             await HandleAutoUpdateAsync();
         }

--- a/DiscordChatExporter.Gui/ViewModels/RootViewModel.cs
+++ b/DiscordChatExporter.Gui/ViewModels/RootViewModel.cs
@@ -108,7 +108,7 @@ namespace DiscordChatExporter.Gui.ViewModels
                 TokenValue = _settingsService.LastToken.Value;
             }
             
-            ((App)System.Windows.Application.Current).setTheme(_settingsService.IsDarkThemeEnabled ? Theme.Dark : Theme.Light);
+            ((App)System.Windows.Application.Current).SetTheme(_settingsService.IsDarkThemeEnabled ? Theme.Dark : Theme.Light);
 
             await HandleAutoUpdateAsync();
         }

--- a/DiscordChatExporter.Gui/ViewModels/RootViewModel.cs
+++ b/DiscordChatExporter.Gui/ViewModels/RootViewModel.cs
@@ -108,7 +108,7 @@ namespace DiscordChatExporter.Gui.ViewModels
                 TokenValue = _settingsService.LastToken.Value;
             }
             
-            ((App)System.Windows.Application.Current).SetTheme(_settingsService.IsDarkThemeEnabled ? Theme.Dark : Theme.Light);
+            Theme.SetAppTheme(_settingsService.IsDarkThemeEnabled ? Theme.Dark : Theme.Light);
 
             await HandleAutoUpdateAsync();
         }

--- a/DiscordChatExporter.Gui/Views/Dialogs/ExportSetupView.xaml
+++ b/DiscordChatExporter.Gui/Views/Dialogs/ExportSetupView.xaml
@@ -163,14 +163,13 @@
             <ToggleButton
                 x:Name="AdvancedSectionToggleButton"
                 Grid.Column="0"
+                Width="24"
+                Height="24"
                 Margin="12"
                 Cursor="Hand"
                 Loaded="AdvancedSectionToggleButton_OnLoaded"
                 Style="{DynamicResource MaterialDesignHamburgerToggleButton}"
-                ToolTip="Show advanced options"
-                Width="24"
-                Height="24">
-            </ToggleButton>
+                ToolTip="Show advanced options" />
 
             <Button
                 Grid.Column="2"

--- a/DiscordChatExporter.Gui/Views/Dialogs/ExportSetupView.xaml
+++ b/DiscordChatExporter.Gui/Views/Dialogs/ExportSetupView.xaml
@@ -163,17 +163,13 @@
             <ToggleButton
                 x:Name="AdvancedSectionToggleButton"
                 Grid.Column="0"
-                Margin="8"
+                Margin="12"
                 Cursor="Hand"
                 Loaded="AdvancedSectionToggleButton_OnLoaded"
-                Style="{DynamicResource MaterialDesignFlatToggleButton}"
-                ToolTip="Show advanced options">
-                <ToggleButton.Content>
-                    <materialDesign:PackIcon
-                        Width="24"
-                        Height="24"
-                        Kind="Menu" />
-                </ToggleButton.Content>
+                Style="{DynamicResource MaterialDesignHamburgerToggleButton}"
+                ToolTip="Show advanced options"
+                Width="24"
+                Height="24">
             </ToggleButton>
 
             <Button

--- a/DiscordChatExporter.Gui/Views/Dialogs/ExportSetupView.xaml
+++ b/DiscordChatExporter.Gui/Views/Dialogs/ExportSetupView.xaml
@@ -48,12 +48,13 @@
                 Margin="8,0,0,0"
                 VerticalAlignment="Center"
                 FontSize="19"
+                FontWeight="Light"
                 TextTrimming="CharacterEllipsis"
                 Visibility="{Binding IsSingleChannel, Converter={x:Static s:BoolToVisibilityConverter.Instance}}">
                 <Run Text="{Binding Channels[0].Category, Mode=OneWay}" ToolTip="{Binding Channels[0].Category, Mode=OneWay}" />
                 <Run Text="/" />
                 <Run
-                    Foreground="{DynamicResource PrimaryHueDarkBrush}"
+                    FontWeight="DemiBold"
                     Text="{Binding Channels[0].Name, Mode=OneWay}"
                     ToolTip="{Binding Channels[0].Name, Mode=OneWay}" />
             </TextBlock>

--- a/DiscordChatExporter.Gui/Views/Dialogs/ExportSetupView.xaml
+++ b/DiscordChatExporter.Gui/Views/Dialogs/ExportSetupView.xaml
@@ -53,7 +53,7 @@
                 <Run Text="{Binding Channels[0].Category, Mode=OneWay}" ToolTip="{Binding Channels[0].Category, Mode=OneWay}" />
                 <Run Text="/" />
                 <Run
-                    Foreground="{DynamicResource PrimaryTextBrush}"
+                    Foreground="{DynamicResource PrimaryHueDarkBrush}"
                     Text="{Binding Channels[0].Name, Mode=OneWay}"
                     ToolTip="{Binding Channels[0].Name, Mode=OneWay}" />
             </TextBlock>

--- a/DiscordChatExporter.Gui/Views/Dialogs/SettingsView.xaml
+++ b/DiscordChatExporter.Gui/Views/Dialogs/SettingsView.xaml
@@ -15,7 +15,6 @@
         <TextBlock
             Margin="16"
             FontSize="17"
-            Style="{DynamicResource MaterialDesignHeadline1TextBlock}"
             Text="Settings" />
 
         <!--  Date format  -->

--- a/DiscordChatExporter.Gui/Views/Dialogs/SettingsView.xaml
+++ b/DiscordChatExporter.Gui/Views/Dialogs/SettingsView.xaml
@@ -56,6 +56,23 @@
                 IsChecked="{Binding IsTokenPersisted}" />
         </DockPanel>
 
+        <!--  Dark/Light theme  -->
+        <DockPanel
+            Background="Transparent"
+            LastChildFill="False"
+            ToolTip="Persist last used token between sessions">
+            <TextBlock
+                Margin="16,8"
+                DockPanel.Dock="Left"
+                Text="Dark theme" />
+            <ToggleButton
+                Margin="16,8"
+                Checked="ToggleButton_Checked"
+                DockPanel.Dock="Right"
+                IsChecked="{Binding IsDarkThemeEnabled}"
+                Unchecked="ToggleButton_Unchecked" />
+        </DockPanel>
+
         <!--  Parallel limit  -->
         <StackPanel Background="Transparent" ToolTip="How many channels can be exported at the same time">
             <TextBlock Margin="16,8">

--- a/DiscordChatExporter.Gui/Views/Dialogs/SettingsView.xaml
+++ b/DiscordChatExporter.Gui/Views/Dialogs/SettingsView.xaml
@@ -15,7 +15,7 @@
         <TextBlock
             Margin="16"
             FontSize="17"
-            Foreground="{DynamicResource PrimaryTextBrush}"
+            Style="{DynamicResource MaterialDesignHeadline1TextBlock}"
             Text="Settings" />
 
         <!--  Date format  -->
@@ -60,7 +60,7 @@
         <StackPanel Background="Transparent" ToolTip="How many channels can be exported at the same time">
             <TextBlock Margin="16,8">
                 <Run Text="Parallel limit:" />
-                <Run Foreground="{DynamicResource PrimaryTextBrush}" Text="{Binding ParallelLimit, Mode=OneWay}" />
+                <Run Text="{Binding ParallelLimit, Mode=OneWay}" />
             </TextBlock>
             <Slider
                 Margin="16,8"

--- a/DiscordChatExporter.Gui/Views/Dialogs/SettingsView.xaml.cs
+++ b/DiscordChatExporter.Gui/Views/Dialogs/SettingsView.xaml.cs
@@ -23,7 +23,7 @@ namespace DiscordChatExporter.Gui.Views.Dialogs
 
         private void setBaseTheme(Theme theme)
         {
-            Theme.SetAppTheme(theme);
+            Theme.SetCurrent(theme);
         }
     }
 }

--- a/DiscordChatExporter.Gui/Views/Dialogs/SettingsView.xaml.cs
+++ b/DiscordChatExporter.Gui/Views/Dialogs/SettingsView.xaml.cs
@@ -23,7 +23,7 @@ namespace DiscordChatExporter.Gui.Views.Dialogs
 
         private void setBaseTheme(Theme theme)
         {
-            ((App)System.Windows.Application.Current).setTheme(theme);
+            ((App)System.Windows.Application.Current).SetTheme(theme);
         }
     }
 }

--- a/DiscordChatExporter.Gui/Views/Dialogs/SettingsView.xaml.cs
+++ b/DiscordChatExporter.Gui/Views/Dialogs/SettingsView.xaml.cs
@@ -23,7 +23,7 @@ namespace DiscordChatExporter.Gui.Views.Dialogs
 
         private void setBaseTheme(Theme theme)
         {
-            ((App)System.Windows.Application.Current).SetTheme(theme);
+            Theme.SetAppTheme(theme);
         }
     }
 }

--- a/DiscordChatExporter.Gui/Views/Dialogs/SettingsView.xaml.cs
+++ b/DiscordChatExporter.Gui/Views/Dialogs/SettingsView.xaml.cs
@@ -21,9 +21,9 @@ namespace DiscordChatExporter.Gui.Views.Dialogs
             setBaseTheme(Theme.Light);
         }
 
-        private void setBaseTheme(IBaseTheme baseTheme)
+        private void setBaseTheme(Theme theme)
         {
-            ((App)System.Windows.Application.Current).setBaseTheme(baseTheme);
+            ((App)System.Windows.Application.Current).setTheme(theme);
         }
     }
 }

--- a/DiscordChatExporter.Gui/Views/Dialogs/SettingsView.xaml.cs
+++ b/DiscordChatExporter.Gui/Views/Dialogs/SettingsView.xaml.cs
@@ -1,10 +1,29 @@
-﻿namespace DiscordChatExporter.Gui.Views.Dialogs
+﻿using MaterialDesignThemes;
+using MaterialDesignThemes.Wpf;
+using System.Windows.Media.Media3D;
+
+namespace DiscordChatExporter.Gui.Views.Dialogs
 {
     public partial class SettingsView
     {
         public SettingsView()
         {
             InitializeComponent();
+        }
+
+        private void ToggleButton_Checked(object sender, System.Windows.RoutedEventArgs e)
+        {
+            setBaseTheme(Theme.Dark);
+        }
+
+        private void ToggleButton_Unchecked(object sender, System.Windows.RoutedEventArgs e)
+        {
+            setBaseTheme(Theme.Light);
+        }
+
+        private void setBaseTheme(IBaseTheme baseTheme)
+        {
+            ((App)System.Windows.Application.Current).setBaseTheme(baseTheme);
         }
     }
 }

--- a/DiscordChatExporter.Gui/Views/RootView.xaml
+++ b/DiscordChatExporter.Gui/Views/RootView.xaml
@@ -46,10 +46,8 @@
             </Grid.RowDefinitions>
 
             <!--  Toolbar  -->
-            <Grid
-                Grid.Row="0"
-                Background="{DynamicResource PrimaryHueMidBrush}"
-                TextElement.Foreground="{DynamicResource SecondaryInverseTextBrush}">
+            <Grid Grid.Row="0" Background="{DynamicResource PrimaryHueMidBrush}">
+
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
@@ -151,25 +149,25 @@
                             <Run Text="1. Open Discord" />
                             <LineBreak />
                             <Run Text="2. Press" />
-                            <Run Foreground="{DynamicResource PrimaryTextBrush}" Text="Ctrl+Shift+I" />
+                            <Run Foreground="{DynamicResource PrimaryHueDarkBrush}" Text="Ctrl+Shift+I" />
                             <Run Text="to show developer tools" />
                             <LineBreak />
                             <Run Text="3. Navigate to the" />
-                            <Run Foreground="{DynamicResource PrimaryTextBrush}" Text="Application" />
+                            <Run Foreground="{DynamicResource PrimaryHueDarkBrush}" Text="Application" />
                             <Run Text="tab" />
                             <LineBreak />
                             <Run Text="4. Select" />
-                            <Run Foreground="{DynamicResource PrimaryTextBrush}" Text="Local Storage" />
+                            <Run Foreground="{DynamicResource PrimaryHueDarkBrush}" Text="Local Storage" />
                             <Run Text="&gt;" />
-                            <Run Foreground="{DynamicResource PrimaryTextBrush}" Text="https://discord.com" />
+                            <Run Foreground="{DynamicResource PrimaryHueDarkBrush}" Text="https://discord.com" />
                             <Run Text="on the left" />
                             <LineBreak />
                             <Run Text="5. Press" />
-                            <Run Foreground="{DynamicResource PrimaryTextBrush}" Text="Ctrl+R" />
+                            <Run Foreground="{DynamicResource PrimaryHueDarkBrush}" Text="Ctrl+R" />
                             <Run Text="to reload" />
                             <LineBreak />
                             <Run Text="6. Find" />
-                            <Run Foreground="{DynamicResource PrimaryTextBrush}" Text="token" />
+                            <Run Foreground="{DynamicResource PrimaryHueDarkBrush}" Text="token" />
                             <Run Text="at the bottom and copy the value" />
                         </TextBlock>
                         <TextBlock Margin="0,24,0,0" FontSize="14">
@@ -195,13 +193,13 @@
                             <Run Text="2. Open your application's settings" />
                             <LineBreak />
                             <Run Text="3. Navigate to the" />
-                            <Run Foreground="{DynamicResource PrimaryTextBrush}" Text="Bot" />
+                            <Run Foreground="{DynamicResource PrimaryHueDarkBrush}" Text="Bot" />
                             <Run Text="section on the left" />
                             <LineBreak />
                             <Run Text="4. Under" />
-                            <Run Foreground="{DynamicResource PrimaryTextBrush}" Text="Token" />
+                            <Run Foreground="{DynamicResource PrimaryHueDarkBrush}" Text="Token" />
                             <Run Text="click" />
-                            <Run Foreground="{DynamicResource PrimaryTextBrush}" Text="Copy" />
+                            <Run Foreground="{DynamicResource PrimaryHueDarkBrush}" Text="Copy" />
                         </TextBlock>
                         <TextBlock Margin="0,24,0,0" FontSize="14">
                             <Run Text="To authorize using user token instead, click" />
@@ -226,7 +224,7 @@
                     <!--  Guilds  -->
                     <Border
                         Grid.Column="0"
-                        BorderBrush="{DynamicResource DividerBrush}"
+                        BorderBrush="{DynamicResource MaterialDesignDivider}"
                         BorderThickness="0,0,1,0">
                         <ListBox
                             ItemsSource="{Binding AvailableGuilds}"
@@ -245,7 +243,7 @@
                                             Width="48"
                                             Height="48"
                                             Margin="12,4,12,4"
-                                            Fill="{DynamicResource DividerBrush}" />
+                                            Fill="{DynamicResource MaterialDesignDivider}" />
 
                                         <!--  Guild icon  -->
                                         <Ellipse
@@ -284,7 +282,7 @@
                                                             Margin="0"
                                                             Padding="0"
                                                             Background="Transparent"
-                                                            BorderBrush="{DynamicResource DividerBrush}"
+                                                            BorderBrush="{DynamicResource MaterialDesignDivider}"
                                                             BorderThickness="0,1,0,0"
                                                             Header="{Binding Name}"
                                                             IsExpanded="False">
@@ -322,7 +320,6 @@
                                             Margin="3,8,8,8"
                                             VerticalAlignment="Center"
                                             FontSize="14"
-                                            Foreground="{DynamicResource PrimaryTextBrush}"
                                             Text="{Binding Name, Mode=OneWay}" />
 
                                         <!--  Is selected checkmark  -->

--- a/DiscordChatExporter.Gui/Views/RootView.xaml
+++ b/DiscordChatExporter.Gui/Views/RootView.xaml
@@ -140,6 +140,11 @@
 
             <!--  Content  -->
             <Grid Grid.Row="2" IsEnabled="{Binding IsBusy, Converter={x:Static converters:InverseBoolConverter.Instance}}">
+                <Grid.Resources>
+                    <Style TargetType="TextBlock">
+                        <Setter Property="FontWeight" Value="Light" />
+                    </Style>
+                </Grid.Resources>
                 <!--  Placeholder / usage instructions  -->
                 <Grid Margin="32,32,8,8" Visibility="{Binding AvailableGuilds, Converter={x:Static s:BoolToVisibilityConverter.InverseInstance}}">
                     <!--  For user token  -->
@@ -149,25 +154,25 @@
                             <Run Text="1. Open Discord" />
                             <LineBreak />
                             <Run Text="2. Press" />
-                            <Run Foreground="{DynamicResource PrimaryHueDarkBrush}" Text="Ctrl+Shift+I" />
+                            <Run FontWeight="Bold" Text="Ctrl+Shift+I" />
                             <Run Text="to show developer tools" />
                             <LineBreak />
                             <Run Text="3. Navigate to the" />
-                            <Run Foreground="{DynamicResource PrimaryHueDarkBrush}" Text="Application" />
+                            <Run FontWeight="Bold" Text="Application" />
                             <Run Text="tab" />
                             <LineBreak />
                             <Run Text="4. Select" />
-                            <Run Foreground="{DynamicResource PrimaryHueDarkBrush}" Text="Local Storage" />
+                            <Run FontWeight="Bold" Text="Local Storage" />
                             <Run Text="&gt;" />
-                            <Run Foreground="{DynamicResource PrimaryHueDarkBrush}" Text="https://discord.com" />
+                            <Run FontWeight="Bold" Text="https://discord.com" />
                             <Run Text="on the left" />
                             <LineBreak />
                             <Run Text="5. Press" />
-                            <Run Foreground="{DynamicResource PrimaryHueDarkBrush}" Text="Ctrl+R" />
+                            <Run FontWeight="Bold" Text="Ctrl+R" />
                             <Run Text="to reload" />
                             <LineBreak />
                             <Run Text="6. Find" />
-                            <Run Foreground="{DynamicResource PrimaryHueDarkBrush}" Text="token" />
+                            <Run FontWeight="Bold" Text="token" />
                             <Run Text="at the bottom and copy the value" />
                         </TextBlock>
                         <TextBlock Margin="0,24,0,0" FontSize="14">
@@ -175,7 +180,10 @@
                             <LineBreak />
                             <Run Text="To authorize using bot token instead, click" />
                             <InlineUIContainer>
-                                <materialDesign:PackIcon Margin="1,0,0,-3" Kind="Account" />
+                                <materialDesign:PackIcon
+                                    Margin="1,0,0,-3"
+                                    Foreground="{DynamicResource PrimaryHueMidBrush}"
+                                    Kind="Account" />
                             </InlineUIContainer>
                         </TextBlock>
                         <TextBlock Margin="0,24,0,0" FontSize="14">
@@ -186,25 +194,34 @@
 
                     <!--  For bot token  -->
                     <StackPanel Visibility="{Binding IsBotToken, Converter={x:Static s:BoolToVisibilityConverter.Instance}}">
-                        <TextBlock FontSize="18" Text="Please provide your bot token to authorize" />
-                        <TextBlock Margin="8,8,0,0" FontSize="14">
+                        <TextBlock
+                            FontSize="18"
+                            FontWeight="Light"
+                            Text="Please provide your bot token to authorize" />
+                        <TextBlock
+                            Margin="8,8,0,0"
+                            FontSize="14"
+                            FontWeight="Light">
                             <Run Text="1. Open Discord developer portal" />
                             <LineBreak />
                             <Run Text="2. Open your application's settings" />
                             <LineBreak />
                             <Run Text="3. Navigate to the" />
-                            <Run Foreground="{DynamicResource PrimaryHueDarkBrush}" Text="Bot" />
+                            <Run FontWeight="Bold" Text="Bot" />
                             <Run Text="section on the left" />
                             <LineBreak />
                             <Run Text="4. Under" />
-                            <Run Foreground="{DynamicResource PrimaryHueDarkBrush}" Text="Token" />
+                            <Run FontWeight="Bold" Text="Token" />
                             <Run Text="click" />
-                            <Run Foreground="{DynamicResource PrimaryHueDarkBrush}" Text="Copy" />
+                            <Run FontWeight="Bold" Text="Copy" />
                         </TextBlock>
                         <TextBlock Margin="0,24,0,0" FontSize="14">
                             <Run Text="To authorize using user token instead, click" />
                             <InlineUIContainer>
-                                <materialDesign:PackIcon Margin="1,0,0,-1" Kind="Robot" />
+                                <materialDesign:PackIcon
+                                    Margin="1,0,0,-1"
+                                    Foreground="{DynamicResource PrimaryHueMidBrush}"
+                                    Kind="Robot" />
                             </InlineUIContainer>
                         </TextBlock>
                         <TextBlock Margin="0,24,0,0" FontSize="14">

--- a/DiscordChatExporter.Gui/Views/RootView.xaml
+++ b/DiscordChatExporter.Gui/Views/RootView.xaml
@@ -46,8 +46,7 @@
             </Grid.RowDefinitions>
 
             <!--  Toolbar  -->
-            <Grid Grid.Row="0" Background="{DynamicResource PrimaryHueMidBrush}">
-
+            <Grid Grid.Row="0" Background="{DynamicResource MaterialDesignDarkBackground}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
@@ -122,8 +121,12 @@
                     Margin="6"
                     Padding="4"
                     Command="{s:Action ShowSettings}"
-                    Style="{DynamicResource MaterialDesignFlatDarkButton}"
+                    Foreground="{DynamicResource MaterialDesignDarkForeground}"
+                    Style="{DynamicResource MaterialDesignFlatButton}"
                     ToolTip="Settings">
+                    <Button.Resources>
+                        <SolidColorBrush x:Key="MaterialDesignFlatButtonClick" Color="#4C4C4C" />
+                    </Button.Resources>
                     <materialDesign:PackIcon
                         Width="24"
                         Height="24"
@@ -134,7 +137,7 @@
             <!--  Progress bar  -->
             <ProgressBar
                 Grid.Row="1"
-                Background="{DynamicResource PrimaryHueMidBrush}"
+                Background="{DynamicResource MaterialDesignDarkBackground}"
                 IsIndeterminate="{Binding IsProgressIndeterminate}"
                 Value="{Binding ProgressManager.Progress, Mode=OneWay}" />
 


### PR DESCRIPTION
Closes #298.

New toggle button for a Dark theme in the settings view:
![image](https://user-images.githubusercontent.com/9027551/94771614-a5ac5380-0385-11eb-956f-f17d8bf19331.png)
The theme changes when toggled. The theme is a saved setting, and the saved theme is set when the app opens. Check out[ this album](https://imgur.com/a/eT4Qx11) to get a feel for what the dark theme looks like.

**Changes to light theme.** Due to the implementation I chose, there are some slight changes to the standard light theme. See [this album](https://imgur.com/a/peFNA6s) for images with captions that explain what's visually different.

**Implementation.** Given my zero prior experience with this software and WPF, I decided to reach for a simplest approach. I probably could have completely preserved the original colors by extracting the colors originally defined in App.xaml into a separate dictionary, defined another dictionary of colors for the dark theme, and then loaded/unloaded these at runtime to swap themes. Instead, I decided to remove all the custom colors/brushes and let the MaterialDesignInXaml (hereafter "MDIX") framework do the work of managing colors of text between dark and light modes.

First, I changed the installation of MDIX to more closely match the MDIX documentation. I chose a bundled theme of blue arbitrarily, which is going to get overwritten during startup by the root view model..
In the settings view, I added a new boolean member to the model and a new toggle button bound to that boolean. When the toggle button is clicked, the theme is changed by calling a method defined in `App.xaml.cs`. This method uses MDIX functionality to change the base theme (light/dark) and the primary color (the dark gray for light, and a light gray for dark).
RootViewModel now sets the theme in `OnViewLoaded`.

**Problems/concerns.**
* **Changes to the original theme's text coloring.** This implementation, as I mentioned, slightly changes how the standard light theme looks, since all the colors were deleted from App. This gives back MDIX control over text colors so that text is always readable regardless of whether Light or Dark is used as the base theme. Nonetheless, there is probably a way to preserve the original look completely by instead specifying separate color/brush dictionaries for both the light and dark theme and then loading/unloading them as needed. Given my inexperience with WPF, I reached for a simpler, less robust implementation to get this working. 
* **Theming from the code behind.** The themes aren't specified in xaml, but rather code (`Theme.cs`). The theme specified in `App.xaml` contains misleading dummy/placeholder colors. Maybe it would be better if both themes were written out clearly in the App.xaml markup (or their own files) to reduce coupling and indirection between the view's appearance and the code behind.
* Increased coupling. `RootViewModel.cs` and `SettingsView.xaml.cs` now both refer to `App.xaml.cs` directly for the theme changing functionality. While I'm not very experienced with WPF/MVVM, I have to imagine that the way I did this isn't the idiomatic way to accomplish theme changing.
Another smaller problem is that the theme gets redundantly re-updated when the settings view gets opened. I'm guessing its because the toggle button fires its Checked event at creation time when the value gets bound from the settings.

If/when these changes are acceptable. I'm happy to squash this to a single commit if preferred. Otherwise, feel free to test, tweak, and merge.

edit: typos
