### PR TITLE
Stop redundantly downloading media when re-exporting

### DIFF
--- a/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
+++ b/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
@@ -29,6 +29,9 @@ namespace DiscordChatExporter.Cli.Commands.Base
         [CommandOption("media", Description = "Download referenced media content.")]
         public bool ShouldDownloadMedia { get; set; }
 
+        [CommandOption("reuse-media", Description = "If the media folder already exists, reuse media inside it to skip downloads.")]
+        public bool ShouldReuseMedia { get; set; }
+
         [CommandOption("dateformat", Description = "Date format used in output.")]
         public string DateFormat { get; set; } = "dd-MMM-yy hh:mm tt";
 
@@ -48,6 +51,7 @@ namespace DiscordChatExporter.Cli.Commands.Base
                 Before,
                 PartitionLimit,
                 ShouldDownloadMedia,
+                ShouldReuseMedia,
                 DateFormat
             );
 

--- a/DiscordChatExporter.Cli/Commands/Base/ExportMultipleCommandBase.cs
+++ b/DiscordChatExporter.Cli/Commands/Base/ExportMultipleCommandBase.cs
@@ -48,6 +48,7 @@ namespace DiscordChatExporter.Cli.Commands.Base
                         Before,
                         PartitionLimit,
                         ShouldDownloadMedia,
+                        ShouldReuseMedia,
                         DateFormat
                     );
 

--- a/DiscordChatExporter.Domain/Exporting/ExportContext.cs
+++ b/DiscordChatExporter.Domain/Exporting/ExportContext.cs
@@ -34,7 +34,7 @@ namespace DiscordChatExporter.Domain.Exporting
             Channels = channels;
             Roles = roles;
 
-            _mediaDownloader = new MediaDownloader(request.OutputMediaDirPath);
+            _mediaDownloader = new MediaDownloader(request.OutputMediaDirPath, request.ShouldReuseMedia);
         }
 
         public string FormatDate(DateTimeOffset date) => date.ToLocalString(Request.DateFormat);

--- a/DiscordChatExporter.Domain/Exporting/ExportRequest.cs
+++ b/DiscordChatExporter.Domain/Exporting/ExportRequest.cs
@@ -30,6 +30,8 @@ namespace DiscordChatExporter.Domain.Exporting
 
         public bool ShouldDownloadMedia { get; }
 
+        public bool ShouldReuseMedia { get; }
+
         public string DateFormat { get; }
 
         public ExportRequest(
@@ -41,6 +43,7 @@ namespace DiscordChatExporter.Domain.Exporting
             DateTimeOffset? before,
             int? partitionLimit,
             bool shouldDownloadMedia,
+            bool shouldReuseMedia,
             string dateFormat)
         {
             Guild = guild;
@@ -51,6 +54,7 @@ namespace DiscordChatExporter.Domain.Exporting
             Before = before;
             PartitionLimit = partitionLimit;
             ShouldDownloadMedia = shouldDownloadMedia;
+            ShouldReuseMedia = shouldReuseMedia;
             DateFormat = dateFormat;
 
             OutputBaseFilePath = GetOutputBaseFilePath(

--- a/DiscordChatExporter.Domain/Exporting/MediaDownloader.cs
+++ b/DiscordChatExporter.Domain/Exporting/MediaDownloader.cs
@@ -30,6 +30,12 @@ namespace DiscordChatExporter.Domain.Exporting
             var fileName = $"{urlParser.FileName}({urlParser.ParentDirectory}).{urlParser.FileExtension}";
             var filePath = Path.Combine(_workingDirPath, fileName);
 
+            if (!File.Exists(filePath))
+            {
+                Directory.CreateDirectory(_workingDirPath);
+                await _httpClient.DownloadAsync(url, filePath);
+            }
+
             return _pathMap[url] = filePath;
         }
     }

--- a/DiscordChatExporter.Domain/Exporting/MediaDownloader.cs
+++ b/DiscordChatExporter.Domain/Exporting/MediaDownloader.cs
@@ -39,14 +39,19 @@ namespace DiscordChatExporter.Domain.Exporting
                 if (_pathMap.TryGetValue(url, out var cachedFilePath))
                     return cachedFilePath;
 
-            var fileName = GetFileNameFromUrl(url);
-            var filePath = Path.Combine(_workingDirPath, fileName);
+                var fileName = GetFileNameFromUrl(url);
+                var filePath = Path.Combine(_workingDirPath, fileName);
 
-            if (!_reuseMedia || !File.Exists(filePath))
-            {
-                Directory.CreateDirectory(_workingDirPath);
-                await _httpClient.DownloadAsync(url, filePath);
-            }
+                if (!_reuseMedia)
+                {
+                    filePath = PathEx.MakeUniqueFilePath(filePath);
+                }
+
+                if (!_reuseMedia || !File.Exists(filePath))
+                {
+                    Directory.CreateDirectory(_workingDirPath);
+                    await _httpClient.DownloadAsync(url, filePath);
+                }
 
                 return _pathMap[url] = filePath;
             });

--- a/DiscordChatExporter.Domain/Exporting/MediaDownloader.cs
+++ b/DiscordChatExporter.Domain/Exporting/MediaDownloader.cs
@@ -63,7 +63,7 @@ namespace DiscordChatExporter.Domain.Exporting
             var urlHash = HashUrl(url);
 
             var fileName = !string.IsNullOrWhiteSpace(originalFileName)
-                ? $"{Path.GetFileNameWithoutExtension(originalFileName).Truncate(41)}-({urlHash.Truncate(5)})-{Path.GetExtension(originalFileName)}"
+                ? $"{Path.GetFileNameWithoutExtension(originalFileName).Truncate(42)}-({urlHash.Truncate(5)}){Path.GetExtension(originalFileName)}"
                 : GetRandomFileName();
 
             return PathEx.EscapePath(fileName);

--- a/DiscordChatExporter.Domain/Exporting/MediaDownloader.cs
+++ b/DiscordChatExporter.Domain/Exporting/MediaDownloader.cs
@@ -13,12 +13,14 @@ namespace DiscordChatExporter.Domain.Exporting
     {
         private readonly HttpClient _httpClient = Singleton.HttpClient;
         private readonly string _workingDirPath;
+        private readonly bool _reuseMedia;
 
         private readonly Dictionary<string, string> _pathMap = new Dictionary<string, string>();
 
-        public MediaDownloader(string workingDirPath)
+        public MediaDownloader(string workingDirPath, bool reuseMedia = false)
         {
             _workingDirPath = workingDirPath;
+            _reuseMedia = reuseMedia;
         }
 
         public async ValueTask<string> DownloadAsync(string url)
@@ -29,7 +31,7 @@ namespace DiscordChatExporter.Domain.Exporting
             var fileName = GetFileNameFromUrl(url);
             var filePath = Path.Combine(_workingDirPath, fileName);
 
-            if (!File.Exists(filePath))
+            if (!_reuseMedia || !File.Exists(filePath))
             {
                 Directory.CreateDirectory(_workingDirPath);
                 await _httpClient.DownloadAsync(url, filePath);

--- a/DiscordChatExporter.Domain/Exporting/MediaDownloader.cs
+++ b/DiscordChatExporter.Domain/Exporting/MediaDownloader.cs
@@ -67,7 +67,7 @@ namespace DiscordChatExporter.Domain.Exporting
         {
             using (var md5 = MD5.Create())
             {
-                var inputBytes = Encoding.ASCII.GetBytes(url);
+                var inputBytes = Encoding.UTF8.GetBytes(url);
                 var hashBytes = md5.ComputeHash(inputBytes);
 
                 var hashBuilder = new StringBuilder();

--- a/DiscordChatExporter.Domain/Exporting/MediaDownloader.cs
+++ b/DiscordChatExporter.Domain/Exporting/MediaDownloader.cs
@@ -22,7 +22,7 @@ namespace DiscordChatExporter.Domain.Exporting
 
         private readonly Dictionary<string, string> _pathMap = new Dictionary<string, string>();
 
-        public MediaDownloader(string workingDirPath, bool reuseMedia = false)
+        public MediaDownloader(string workingDirPath, bool reuseMedia)
         {
             _workingDirPath = workingDirPath;
             _reuseMedia = reuseMedia;

--- a/DiscordChatExporter.Gui/Services/SettingsService.cs
+++ b/DiscordChatExporter.Gui/Services/SettingsService.cs
@@ -14,6 +14,8 @@ namespace DiscordChatExporter.Gui.Services
 
         public int ParallelLimit { get; set; } = 1;
 
+        public bool ShouldReuseMedia { get; set; } = false;
+
         public AuthToken? LastToken { get; set; }
 
         public ExportFormat LastExportFormat { get; set; } = ExportFormat.HtmlDark;

--- a/DiscordChatExporter.Gui/ViewModels/Dialogs/SettingsViewModel.cs
+++ b/DiscordChatExporter.Gui/ViewModels/Dialogs/SettingsViewModel.cs
@@ -31,6 +31,12 @@ namespace DiscordChatExporter.Gui.ViewModels.Dialogs
             get => _settingsService.ParallelLimit;
             set => _settingsService.ParallelLimit = value.Clamp(1, 10);
         }
+        
+        public bool ShouldReuseMedia
+        {
+            get => _settingsService.ShouldReuseMedia;
+            set => _settingsService.ShouldReuseMedia = value;
+        }
 
         public SettingsViewModel(SettingsService settingsService)
         {

--- a/DiscordChatExporter.Gui/ViewModels/RootViewModel.cs
+++ b/DiscordChatExporter.Gui/ViewModels/RootViewModel.cs
@@ -195,6 +195,7 @@ namespace DiscordChatExporter.Gui.ViewModels
                         dialog.Before,
                         dialog.PartitionLimit,
                         dialog.ShouldDownloadMedia,
+                        false,
                         _settingsService.DateFormat
                     );
 

--- a/DiscordChatExporter.Gui/ViewModels/RootViewModel.cs
+++ b/DiscordChatExporter.Gui/ViewModels/RootViewModel.cs
@@ -195,7 +195,7 @@ namespace DiscordChatExporter.Gui.ViewModels
                         dialog.Before,
                         dialog.PartitionLimit,
                         dialog.ShouldDownloadMedia,
-                        false,
+                        _settingsService.ShouldReuseMedia,
                         _settingsService.DateFormat
                     );
 

--- a/DiscordChatExporter.Gui/Views/Dialogs/SettingsView.xaml
+++ b/DiscordChatExporter.Gui/Views/Dialogs/SettingsView.xaml
@@ -7,7 +7,7 @@
     xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:s="https://github.com/canton7/Stylet"
-    Width="300"
+    Width="310"
     d:DataContext="{d:DesignInstance Type=dialogs:SettingsViewModel}"
     Style="{DynamicResource MaterialDesignRoot}"
     mc:Ignorable="d">
@@ -54,6 +54,21 @@
                 Margin="16,8"
                 DockPanel.Dock="Right"
                 IsChecked="{Binding IsTokenPersisted}" />
+        </DockPanel>
+
+        <!--  Persist token  -->
+        <DockPanel
+            Background="Transparent"
+            LastChildFill="False"
+            ToolTip="If the media folder already exists, reuse media inside it to skip downloads">
+            <TextBlock
+                Margin="16,8"
+                DockPanel.Dock="Left"
+                Text="Reuse previously downloaded media" />
+            <ToggleButton
+                Margin="16,8"
+                DockPanel.Dock="Right"
+                IsChecked="{Binding ShouldReuseMedia}" />
         </DockPanel>
 
         <!--  Parallel limit  -->


### PR DESCRIPTION
Closes #382 

Heya, this PR is mostly meant to facilitate discussion about #382. Maybe I should keep discussion there instead, but I don't know. Anyway, this PR demonstrates a minimal (though arguably not robust) way to avoid redownloading media when re-performing an export.

**Implementation.** When parsing a URL, `MediaUrlParser` also extracts the parent directory of the file being downloaded. `MediaDownloader` adds this directory in parenthesis to the filename when saving the files to disk. Example: if I embed `bagel.png` in a message and then exported the channel, it might now appear locally as `bagel(5QO5WVLYSEI).png`. In this case, `5QO5WVLYSEI` is the message ID. The idea is that the filename + message ID should uniquely identify any media, so if someone else also uploads a `bagel.png` after that message, then that file would still get downloaded as well, it would just have a different message ID in the filename.

**Concerns.**
* **Technical--fragility.** This implementation creates a dependency on the URL that a piece of media is found at: any media must have a parent directory (e.g. server/guild ID or message ID), which I imagine is pretty safe to depend on. It also depends on the combination of this parent directory and the filename as a reliable means to uniquely identify any media. If this is ever not true, then we may incorrectly avoid downloading a piece of media thinking that we already downloaded it. A more stable way to implement this change might be to let the model class that represents a piece of media decide what information uniquely identifies a piece of a media of that type and also the filename it should be given when saving it locally. This is obviously more complicated than just passing a URL to media downloader, so I went for the simple approach I described, and I can only hope it doesn't horribly fail in some situation I did not consider.
* **Technical--inefficacy/accessibility of this feature.** This caching mechanism only works when redoing an export that's already been done with the same settings (i.e. one that would cause a "File already exists--do you wish to overwrite?" filesystem dialog). For example, if I export a channel with an After Date of 2 days ago and then do the same export with an After Date of 3 days ago, this would create two separate media directories (no change here), so we would still end up redundantly downloading the media that both exports download. I am not sure of all the settings that change the filename/media directory, but the After Date is an example. I hope I was able to explain this decently enough. I imagine that this functionality would be used mostly when re-exporting the entirety of a channel on some periodic schedule.
* **User experience / potential controversy.** Adding this information to the filenames makes them more noisy. For users browsing the downloaded media after they've exported a channel, this may be annoying. `bagel.png` is nicer to read than `bagel(5QO5WVLYSEI).png` (or some variant of it). In my personal experience, most uploaded media isn't named, so I imagine the filenames of most downloaded media were already made mostly of gibberish beforehand--so this change probably wouldn't make the usual situation any worse.

I am interested in your thoughts. Let me know if you would like some clarification.
