### PR TITLE
[JSON] Add embed color

### DIFF
--- a/DiscordChatExporter.Domain/Exporting/Writers/JsonMessageWriter.cs
+++ b/DiscordChatExporter.Domain/Exporting/Writers/JsonMessageWriter.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Drawing;
+using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
 using DiscordChatExporter.Domain.Discord.Models;
@@ -113,6 +114,9 @@ namespace DiscordChatExporter.Domain.Exporting.Writers
             _writer.WriteString("url", embed.Url);
             _writer.WriteString("timestamp", embed.Timestamp);
             _writer.WriteString("description", FormatMarkdown(embed.Description));
+
+            if (embed.Color != null)
+                _writer.WriteString("color", ColorTranslator.ToHtml(embed.Color.Value));
 
             if (embed.Author != null)
                 await WriteEmbedAuthorAsync(embed.Author);


### PR DESCRIPTION
Closes #396.

Adds `color` field to `embeds` items in JSON output. Color is stored as an HTML hex color code. The `color` field will be omitted if the embed doesn't have a color.

![image](https://user-images.githubusercontent.com/9027551/95650464-e0af3500-0ab1-11eb-9cf2-27061445eed0.png)
