### PR TITLE
Add retry policy to MediaDownloader to accommodate short network outages during download

### DIFF
--- a/DiscordChatExporter.Domain/Exporting/MediaDownloader.cs
+++ b/DiscordChatExporter.Domain/Exporting/MediaDownloader.cs
@@ -26,22 +26,7 @@ namespace DiscordChatExporter.Domain.Exporting
 
             _httpRequestPolicy = Policy
                 .Handle<IOException>()
-                .WaitAndRetryAsync(GenerateSleepDurations());
-
-            IEnumerable<TimeSpan> GenerateSleepDurations()
-            {
-                int totalWait = 0;
-                int i = 0;
-                while (true)
-                {
-                    int wait = (int)Math.Pow(2, i) * FIRST_RETRY_WAIT_MS;
-                    if (totalWait + wait > MAX_RETRY_WAIT_MS) yield break;
-
-                    totalWait += wait;
-                    yield return TimeSpan.FromMilliseconds(wait);
-                    i++;
-                }
-            }
+                .WaitAndRetryAsync(8, i => TimeSpan.FromSeconds(0.5 * i));
         }
 
         public async ValueTask<string> DownloadAsync(string url)
@@ -65,8 +50,6 @@ namespace DiscordChatExporter.Domain.Exporting
 
     internal partial class MediaDownloader
     {
-        private static int FIRST_RETRY_WAIT_MS = 250;
-        private static int MAX_RETRY_WAIT_MS = 32 * 1000;
         private static string GetRandomFileName() => Guid.NewGuid().ToString().Replace("-", "").Substring(0, 16);
 
         private static string GetFileNameFromUrl(string url)

--- a/DiscordChatExporter.Domain/Exporting/MediaDownloader.cs
+++ b/DiscordChatExporter.Domain/Exporting/MediaDownloader.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using DiscordChatExporter.Domain.Internal;
 using DiscordChatExporter.Domain.Internal.Extensions;
+using Polly;
+using Polly.Retry;
 
 namespace DiscordChatExporter.Domain.Exporting
 {
@@ -13,32 +16,57 @@ namespace DiscordChatExporter.Domain.Exporting
     {
         private readonly HttpClient _httpClient = Singleton.HttpClient;
         private readonly string _workingDirPath;
+        private readonly AsyncRetryPolicy _httpRequestPolicy;
 
         private readonly Dictionary<string, string> _pathMap = new Dictionary<string, string>();
 
         public MediaDownloader(string workingDirPath)
         {
             _workingDirPath = workingDirPath;
+
+            _httpRequestPolicy = Policy
+                .Handle<IOException>()
+                .WaitAndRetryAsync(GenerateSleepDurations());
+
+            IEnumerable<TimeSpan> GenerateSleepDurations()
+            {
+                int totalWait = 0;
+                int i = 0;
+                while (true)
+                {
+                    int wait = (int)Math.Pow(2, i) * FIRST_RETRY_WAIT_MS;
+                    if (totalWait + wait > MAX_RETRY_WAIT_MS) yield break;
+
+                    totalWait += wait;
+                    yield return TimeSpan.FromMilliseconds(wait);
+                    i++;
+                }
+            }
         }
 
         public async ValueTask<string> DownloadAsync(string url)
         {
-            if (_pathMap.TryGetValue(url, out var cachedFilePath))
-                return cachedFilePath;
+            return await _httpRequestPolicy.ExecuteAsync(async () =>
+            {
+                if (_pathMap.TryGetValue(url, out var cachedFilePath))
+                    return cachedFilePath;
 
-            var fileName = GetFileNameFromUrl(url);
-            var filePath = PathEx.MakeUniqueFilePath(Path.Combine(_workingDirPath, fileName));
+                var fileName = GetFileNameFromUrl(url);
+                var filePath = PathEx.MakeUniqueFilePath(Path.Combine(_workingDirPath, fileName));
 
-            Directory.CreateDirectory(_workingDirPath);
+                Directory.CreateDirectory(_workingDirPath);
 
-            await _httpClient.DownloadAsync(url, filePath);
+                await _httpClient.DownloadAsync(url, filePath);
 
-            return _pathMap[url] = filePath;
+                return _pathMap[url] = filePath;
+            });
         }
     }
 
     internal partial class MediaDownloader
     {
+        private static int FIRST_RETRY_WAIT_MS = 250;
+        private static int MAX_RETRY_WAIT_MS = 32 * 1000;
         private static string GetRandomFileName() => Guid.NewGuid().ToString().Replace("-", "").Substring(0, 16);
 
         private static string GetFileNameFromUrl(string url)


### PR DESCRIPTION
Closes #399 and Closes #402.

In the event of an `IOException` when downloading media, we will retry until we hit pre-defined total wait time.

I will say I don't really know how to precisely test this. I just put a breakpoint on the media download code and crudely pulled the ethernet cable out of my computer or switched to WiFi.

