### PR TITLE
Add "unix" and "unixms" options for date format

### DIFF
--- a/DiscordChatExporter.Domain/Exporting/ExportContext.cs
+++ b/DiscordChatExporter.Domain/Exporting/ExportContext.cs
@@ -37,7 +37,12 @@ namespace DiscordChatExporter.Domain.Exporting
             _mediaDownloader = new MediaDownloader(request.OutputMediaDirPath);
         }
 
-        public string FormatDate(DateTimeOffset date) => date.ToLocalString(Request.DateFormat);
+        public string FormatDate(DateTimeOffset date) => Request.DateFormat switch
+        {
+            "unix" => date.ToUnixTimeSeconds().ToString(),
+            "unixms" => date.ToUnixTimeMilliseconds().ToString(),
+            var df => date.ToLocalString(df),
+        };
 
         public Member? TryGetMember(string id) =>
             Members.FirstOrDefault(m => m.Id == id);


### PR DESCRIPTION
Closes #220.
For the `--dateFormat` option, adds values:
* `unix` for a unix timestamp (seconds since epoch).
* `unixms` for milliseconds since epoch.

Example using `--dateformat unix`:
![image](https://user-images.githubusercontent.com/9027551/95666318-7b495b80-0b26-11eb-96f1-8980c24c4708.png)
