### PR TITLE
[GUI] Fix content bg color on first screen to match the second screen

### DIFF
--- a/DiscordChatExporter.Gui/Views/RootView.xaml
+++ b/DiscordChatExporter.Gui/Views/RootView.xaml
@@ -142,7 +142,10 @@
                 Value="{Binding ProgressManager.Progress, Mode=OneWay}" />
 
             <!--  Content  -->
-            <Grid Grid.Row="2" IsEnabled="{Binding IsBusy, Converter={x:Static converters:InverseBoolConverter.Instance}}">
+            <Grid
+                Grid.Row="2"
+                Background="{DynamicResource MaterialDesignCardBackground}"
+                IsEnabled="{Binding IsBusy, Converter={x:Static converters:InverseBoolConverter.Instance}}">
                 <Grid.Resources>
                     <Style TargetType="TextBlock">
                         <Setter Property="FontWeight" Value="Light" />


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/9027551/96214146-bbef0d80-0f48-11eb-8d29-0844a44c836e.png)

After:
![image](https://user-images.githubusercontent.com/9027551/96214062-877b5180-0f48-11eb-998c-b91f84209e83.png)

Apologies for the blue-light filtering in the images :).