### PR TITLE
[HTML] Rich rendering support for audio and video embeds

### DIFF
--- a/DiscordChatExporter.Domain/Discord/Models/Attachment.cs
+++ b/DiscordChatExporter.Domain/Discord/Models/Attachment.cs
@@ -23,6 +23,11 @@ namespace DiscordChatExporter.Domain.Discord.Models
         public bool IsImage =>
             ImageFileExtensions.Contains(Path.GetExtension(FileName), StringComparer.OrdinalIgnoreCase);
 
+        public bool IsVideo =>
+            WebSafeVideoFileExtensions.Contains(Path.GetExtension(FileName), StringComparer.OrdinalIgnoreCase);
+        public bool IsAudio =>
+            WebSafeAudioFileExtensions.Contains(Path.GetExtension(FileName), StringComparer.OrdinalIgnoreCase);
+
         public bool IsSpoiler =>
             IsImage && FileName.StartsWith("SPOILER_", StringComparison.Ordinal);
 
@@ -43,7 +48,9 @@ namespace DiscordChatExporter.Domain.Discord.Models
 
     public partial class Attachment
     {
-        private static readonly string[] ImageFileExtensions = {".jpg", ".jpeg", ".png", ".gif", ".bmp"};
+        private static readonly string[] ImageFileExtensions = {".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp"};
+        private static readonly string[] WebSafeVideoFileExtensions = { ".mp4", ".webm" };
+        private static readonly string[] WebSafeAudioFileExtensions = { ".mp3", ".wav", ".ogg", ".flac", ".m4a" };
 
         public static Attachment Parse(JsonElement json)
         {

--- a/DiscordChatExporter.Domain/Discord/Models/Attachment.cs
+++ b/DiscordChatExporter.Domain/Discord/Models/Attachment.cs
@@ -29,7 +29,7 @@ namespace DiscordChatExporter.Domain.Discord.Models
             WebSafeAudioFileExtensions.Contains(Path.GetExtension(FileName), StringComparer.OrdinalIgnoreCase);
 
         public bool IsSpoiler =>
-            IsImage && FileName.StartsWith("SPOILER_", StringComparison.Ordinal);
+            (IsImage || IsVideo || IsAudio) && FileName.StartsWith("SPOILER_", StringComparison.Ordinal);
 
         public FileSize FileSize { get; }
 

--- a/DiscordChatExporter.Domain/Exporting/Writers/Html/Core.css
+++ b/DiscordChatExporter.Domain/Exporting/Writers/Html/Core.css
@@ -55,7 +55,9 @@ img {
 }
 
 .spoiler {
-    width: fit-content;
+    /* width: fit-content; */
+    display: inline-block;
+    /* This is more consistent across browsers, the old attribute worked well under Chrome but not FireFox. */
 }
 
 .spoiler--hidden {
@@ -84,24 +86,28 @@ img {
     box-shadow: 0 0 1px 1px rgba(0, 0, 0, 0.1);
 }
 
-.spoiler--hidden .spoiler-image img {
+.spoiler--hidden .spoiler-image * {
     filter: blur(44px);
 }
 
-.spoiler--hidden .spoiler-image:after {
-    content: "SPOILER";
-    color: #dcddde;
-    background-color: rgba(0, 0, 0, 0.6);
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -50%);
-    font-weight: 600;
-    padding: 0.5em 0.7em;
-    border-radius: 20px;
-    letter-spacing: 0.05em;
-    font-size: 0.9em;
-}
+    .spoiler--hidden .spoiler-image:after {
+        content: "SPOILER";
+        color: #dcddde;
+        background-color: rgba(0, 0, 0, 0.6);
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
+        font-weight: 600;
+        /* padding: 0.5em 0.7em; */
+        padding: 100%;
+        /* This ruins those beutifully rounded buttons, but it's needed to prevent a FireFox bug with video and audio elemnts. */
+        /* The bug is that you can click trough the spoiler layer and play the video or audio, I could not identify the cause. */
+        /* I leave this here, in case someone is brave enough to venture in to madness that is undocumented browser behaviour. */
+        border-radius: 20px;
+        letter-spacing: 0.05em;
+        font-size: 0.9em;
+    }
 
 .spoiler--hidden:hover .spoiler-image:after {
     color: #fff;

--- a/DiscordChatExporter.Domain/Exporting/Writers/Html/MessageGroupTemplate.cshtml
+++ b/DiscordChatExporter.Domain/Exporting/Writers/Html/MessageGroupTemplate.cshtml
@@ -59,16 +59,38 @@
                         }
                         else
                         {
-                            <a href="@await ResolveUrlAsync(attachment.Url)">
-                                @if (attachment.IsImage)
-                                {
+                            @if (attachment.IsImage)
+                            {
+                                <a href="@await ResolveUrlAsync(attachment.Url)">
+                                    @($"Image: {attachment.FileName} ({attachment.FileSize})")
+                                    <br/>
                                     <img class="chatlog__attachment-thumbnail" src="@await ResolveUrlAsync(attachment.Url)" alt="Attachment">
-                                }
-                                else
-                                {
+                                </a>
+                            }
+                            else if (attachment.IsVideo)
+                            {
+                                <a href="@await ResolveUrlAsync(attachment.Url)">
+                                    @($"Video: {attachment.FileName} ({attachment.FileSize})")
+                                </a>
+                                <br/>
+                                <video controls class="chatlog__attachment-thumbnail">
+                                    <source src="@await ResolveUrlAsync(attachment.Url)" alt="Video Attachment">
+                                </video>
+                            }
+                            else if (attachment.IsAudio)
+                            {
+                                <a href="@await ResolveUrlAsync(attachment.Url)">
+                                    @($"Audio: {attachment.FileName} ({attachment.FileSize})")
+                                </a>
+                                <br/>
+                                <audio controls class="chatlog__attachment-thumbnail" src="@await ResolveUrlAsync(attachment.Url)" alt="Audio Attachment" />
+                            }
+                            else
+                            {
+                                <a href="@await ResolveUrlAsync(attachment.Url)">
                                     @($"Attachment: {attachment.FileName} ({attachment.FileSize})")
-                                }
-                            </a>
+                                </a>
+                            }
                         }
                     </div>
                 }

--- a/DiscordChatExporter.Domain/Exporting/Writers/Html/MessageGroupTemplate.cshtml
+++ b/DiscordChatExporter.Domain/Exporting/Writers/Html/MessageGroupTemplate.cshtml
@@ -41,57 +41,52 @@
 
             <div class="chatlog__message @isPinnedStyle" data-message-id="@message.Id" id="message-@message.Id">
                 <div class="chatlog__content">
-                    <div class="markdown">@Raw(FormatMarkdown(message.Content)) @if (message.EditedTimestamp != null) {<span class="chatlog__edited-timestamp" title="@FormatDate(message.EditedTimestamp.Value)">(edited)</span>}</div>
+                    <div class="markdown">@Raw(FormatMarkdown(message.Content)) @if (message.EditedTimestamp != null)
+                    {<span class="chatlog__edited-timestamp" title="@FormatDate(message.EditedTimestamp.Value)">(edited)</span>}</div>
                 </div>
+
 
                 @foreach (var attachment in message.Attachments)
                 {
                     <div class="chatlog__attachment">
-                        @if (attachment.IsSpoiler)
-                        {
-                            <div class="spoiler spoiler--hidden" onclick="showSpoiler(event, this)">
-                                <div class="spoiler-image">
+                        <div class="@((attachment.IsSpoiler ? "spoiler spoiler--hidden" : ""))" onclick="@((attachment.IsSpoiler ? "showSpoiler(event, this)" : ""))">
+                            <div class="@((attachment.IsSpoiler ? "spoiler-image" : ""))">
+
+                                @if (attachment.IsImage)
+                                {
                                     <a href="@await ResolveUrlAsync(attachment.Url)">
+                                        @($"Image: {attachment.FileName} ({attachment.FileSize})")
+                                        <br />
                                         <img class="chatlog__attachment-thumbnail" src="@await ResolveUrlAsync(attachment.Url)" alt="Attachment">
                                     </a>
-                                </div>
+                                }
+                                else if (attachment.IsVideo)
+                                {
+                                    <a href="@await ResolveUrlAsync(attachment.Url)">
+                                        @($"Video: {attachment.FileName} ({attachment.FileSize})")
+                                    </a>
+                                    <br />
+                                    <video controls class="chatlog__attachment-thumbnail">
+                                        <source src="@await ResolveUrlAsync(attachment.Url)" alt="Video Attachment">
+                                    </video>
+                                }
+                                else if (attachment.IsAudio)
+                                {
+                                    <a href="@await ResolveUrlAsync(attachment.Url)">
+                                        @($"Audio: {attachment.FileName} ({attachment.FileSize})")
+                                    </a>
+                                    <br />
+                                    <audio controls class="chatlog__attachment-thumbnail" src="@await ResolveUrlAsync(attachment.Url)" alt="Audio Attachment" />
+                                }
+                                else
+                                {
+                                    <a href="@await ResolveUrlAsync(attachment.Url)">
+                                        @($"Attachment: {attachment.FileName} ({attachment.FileSize})")
+                                    </a>
+                                }
+
                             </div>
-                        }
-                        else
-                        {
-                            @if (attachment.IsImage)
-                            {
-                                <a href="@await ResolveUrlAsync(attachment.Url)">
-                                    @($"Image: {attachment.FileName} ({attachment.FileSize})")
-                                    <br/>
-                                    <img class="chatlog__attachment-thumbnail" src="@await ResolveUrlAsync(attachment.Url)" alt="Attachment">
-                                </a>
-                            }
-                            else if (attachment.IsVideo)
-                            {
-                                <a href="@await ResolveUrlAsync(attachment.Url)">
-                                    @($"Video: {attachment.FileName} ({attachment.FileSize})")
-                                </a>
-                                <br/>
-                                <video controls class="chatlog__attachment-thumbnail">
-                                    <source src="@await ResolveUrlAsync(attachment.Url)" alt="Video Attachment">
-                                </video>
-                            }
-                            else if (attachment.IsAudio)
-                            {
-                                <a href="@await ResolveUrlAsync(attachment.Url)">
-                                    @($"Audio: {attachment.FileName} ({attachment.FileSize})")
-                                </a>
-                                <br/>
-                                <audio controls class="chatlog__attachment-thumbnail" src="@await ResolveUrlAsync(attachment.Url)" alt="Audio Attachment" />
-                            }
-                            else
-                            {
-                                <a href="@await ResolveUrlAsync(attachment.Url)">
-                                    @($"Attachment: {attachment.FileName} ({attachment.FileSize})")
-                                </a>
-                            }
-                        }
+                        </div>
                     </div>
                 }
 
@@ -212,22 +207,22 @@
                                         <img class="chatlog__embed-footer-icon" src="@await ResolveUrlAsync(embed.Footer.IconUrl)" alt="Footer icon">
                                     }
 
-                                        <span class="chatlog__embed-footer-text">
-                                            @if (!string.IsNullOrWhiteSpace(embed.Footer?.Text))
-                                            {
-                                                @embed.Footer.Text
-                                            }
+                                    <span class="chatlog__embed-footer-text">
+                                        @if (!string.IsNullOrWhiteSpace(embed.Footer?.Text))
+                                        {
+                                            @embed.Footer.Text
+                                        }
 
-                                            @if (!string.IsNullOrWhiteSpace(embed.Footer?.Text) && embed.Timestamp != null)
-                                            {
-                                                @(" • ")
-                                            }
+                                        @if (!string.IsNullOrWhiteSpace(embed.Footer?.Text) && embed.Timestamp != null)
+                                        {
+                                            @(" • ")
+                                        }
 
-                                            @if (embed.Timestamp != null)
-                                            {
-                                                @FormatDate(embed.Timestamp.Value)
-                                            }
-                                        </span>
+                                        @if (embed.Timestamp != null)
+                                        {
+                                            @FormatDate(embed.Timestamp.Value)
+                                        }
+                                    </span>
                                 </div>
                             }
                         </div>


### PR DESCRIPTION
Closes #333

The changes make it so that the HTML writer embeds some web safe audio and video files.

In addition to that the ".webp" file format is also added to image embeds, which is on par with the default behaviour of Discord.

The new supported formats are:

Image:

- .WEBP


Audio:

-  .MP3
- .WAV
- .OGG
- .FLAC
- .M4A

Video:

- .MP4
- .WEBM

Image Previews:

Audio:
![image](https://user-images.githubusercontent.com/2854477/99089875-87698280-25d6-11eb-9650-1ea57503c977.png)

Video:
![image](https://user-images.githubusercontent.com/2854477/99089976-aec04f80-25d6-11eb-925f-9b6973f85bbf.png)

The file name and size are still there (above the embed) to help with searching and to keep it consistent, across all types of embeds. The same applies for images too:

Image:
![image](https://user-images.githubusercontent.com/2854477/99090261-0ced3280-25d7-11eb-827b-80e030233693.png)
