### PR TITLE
[CLI] Print error and exit if reuse-media option is used without media option

### DIFF
--- a/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
+++ b/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
@@ -75,8 +75,7 @@ namespace DiscordChatExporter.Cli.Commands.Base
         {
             if (ShouldReuseMedia && !ShouldDownloadMedia)
             {
-                Console.WriteLine("The \"--reuse-media\" option cannot be used without the \"--media\" option.");
-                Environment.Exit(1);
+                throw new CommandException("The --reuse-media option cannot be used without the --media option.");
             }
         }
         protected async ValueTask ExportAsync(IConsole console, Channel channel)

--- a/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
+++ b/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
@@ -69,6 +69,34 @@ namespace DiscordChatExporter.Cli.Commands.Base
             console.Output.WriteLine("Done.");
         }
 
+        public void ExecuteAsync()
+        {
+            if (ShouldReuseMedia && !ShouldDownloadMedia)
+            {
+                var shouldDownloadMediaOptionName = GetAttributeName(nameof(ShouldDownloadMedia));
+                var shouldReuseMediaOptionName = GetAttributeName(nameof(ShouldReuseMedia));
+
+                Console.WriteLine($"The \"--{shouldReuseMediaOptionName}\" option cannot be used without the \"--{shouldDownloadMediaOptionName}\" option.");
+                Environment.Exit(1);
+            }
+
+            string GetAttributeName(string name)
+            {
+                var property = typeof(ExportCommandBase).GetProperty(name);
+                if (property == null) throw new Exception("Could not find property: " + name);
+
+                var attributes = property.GetCustomAttributes(true);
+                foreach (var attribute in attributes)
+                {
+                    var commandOptionAttribute = attribute as CommandOptionAttribute;
+                    if (commandOptionAttribute != null && commandOptionAttribute.Name != null)
+                    {
+                        return commandOptionAttribute.Name;
+                    }
+                }
+                throw new Exception("Unable to find name of property");
+            }
+        }
         protected async ValueTask ExportAsync(IConsole console, Channel channel)
         {
             var guild = await GetDiscordClient().GetGuildAsync(channel.GuildId);

--- a/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
+++ b/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading.Tasks;
 using CliFx;
 using CliFx.Attributes;
+using CliFx.Exceptions;
 using CliFx.Utilities;
 using DiscordChatExporter.Domain.Discord.Models;
 using DiscordChatExporter.Domain.Exporting;
@@ -11,6 +12,7 @@ namespace DiscordChatExporter.Cli.Commands.Base
 {
     public abstract class ExportCommandBase : TokenCommandBase
     {
+
         [CommandOption("output", 'o',
             Description = "Output file or directory path.")]
         public string OutputPath { get; set; } = Directory.GetCurrentDirectory();
@@ -73,28 +75,8 @@ namespace DiscordChatExporter.Cli.Commands.Base
         {
             if (ShouldReuseMedia && !ShouldDownloadMedia)
             {
-                var shouldDownloadMediaOptionName = GetAttributeName(nameof(ShouldDownloadMedia));
-                var shouldReuseMediaOptionName = GetAttributeName(nameof(ShouldReuseMedia));
-
-                Console.WriteLine($"The \"--{shouldReuseMediaOptionName}\" option cannot be used without the \"--{shouldDownloadMediaOptionName}\" option.");
+                Console.WriteLine("The \"--reuse-media\" option cannot be used without the \"--media\" option.");
                 Environment.Exit(1);
-            }
-
-            string GetAttributeName(string name)
-            {
-                var property = typeof(ExportCommandBase).GetProperty(name);
-                if (property == null) throw new Exception("Could not find property: " + name);
-
-                var attributes = property.GetCustomAttributes(true);
-                foreach (var attribute in attributes)
-                {
-                    var commandOptionAttribute = attribute as CommandOptionAttribute;
-                    if (commandOptionAttribute != null && commandOptionAttribute.Name != null)
-                    {
-                        return commandOptionAttribute.Name;
-                    }
-                }
-                throw new Exception("Unable to find name of property");
             }
         }
         protected async ValueTask ExportAsync(IConsole console, Channel channel)

--- a/DiscordChatExporter.Cli/Commands/ExportChannelCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/ExportChannelCommand.cs
@@ -12,7 +12,10 @@ namespace DiscordChatExporter.Cli.Commands
             Description = "Channel ID.")]
         public string ChannelId { get; set; } = "";
 
-        public override async ValueTask ExecuteAsync(IConsole console) =>
+        public override async ValueTask ExecuteAsync(IConsole console)
+        {
+            base.ExecuteAsync();
             await ExportAsync(console, ChannelId);
+        }
     }
 }


### PR DESCRIPTION
Closes #425.

`export -c <channel id> --token <token> --reuse-media` results in:
![image](https://user-images.githubusercontent.com/9027551/99128522-0495f700-25d9-11eb-9e33-867f7f012b1e.png)
