### PR TITLE
[CLI] Display channel name for errors during ExportMultipleAsync

### DIFF
--- a/DiscordChatExporter.Cli/Commands/Base/ExportMultipleCommandBase.cs
+++ b/DiscordChatExporter.Cli/Commands/Base/ExportMultipleCommandBase.cs
@@ -32,7 +32,7 @@ namespace DiscordChatExporter.Cli.Commands.Base
             var operations = progress.Wrap().CreateOperations(channels.Count);
 
             var successfulExportCount = 0;
-            var errors = new ConcurrentBag<string>();
+            var errors = new ConcurrentBag<(Channel, string)>();
 
             await channels.Zip(operations).ParallelForEachAsync(async tuple =>
             {
@@ -61,7 +61,7 @@ namespace DiscordChatExporter.Cli.Commands.Base
                 }
                 catch (DiscordChatExporterException ex) when (!ex.IsCritical)
                 {
-                    errors.Add(ex.Message);
+                    errors.Add((channel, ex.Message));
                 }
                 finally
                 {
@@ -71,8 +71,8 @@ namespace DiscordChatExporter.Cli.Commands.Base
 
             console.Output.WriteLine();
 
-            foreach (var error in errors)
-                console.Error.WriteLine(error);
+            foreach (var (channel, error) in errors)
+                console.Error.WriteLine($"Channel '{channel}': {error}");
 
             console.Output.WriteLine($"Successfully exported {successfulExportCount} channel(s).");
         }

--- a/DiscordChatExporter.Domain/Exceptions/DiscordChatExporterException.cs
+++ b/DiscordChatExporter.Domain/Exceptions/DiscordChatExporterException.cs
@@ -46,9 +46,9 @@ Failed to perform an HTTP request.
             return new DiscordChatExporterException(message);
         }
 
-        internal static DiscordChatExporterException ChannelIsEmpty(string channel)
+        internal static DiscordChatExporterException ChannelIsEmpty()
         {
-            var message = $"Channel '{channel}' contains no messages for the specified period.";
+            var message = $"No messages for the specified period.";
             return new DiscordChatExporterException(message);
         }
     }

--- a/DiscordChatExporter.Domain/Exporting/ChannelExporter.cs
+++ b/DiscordChatExporter.Domain/Exporting/ChannelExporter.cs
@@ -59,7 +59,7 @@ namespace DiscordChatExporter.Domain.Exporting
 
             // Throw if no messages were exported
             if (!exportedAnything)
-                throw DiscordChatExporterException.ChannelIsEmpty(request.Channel.Name);
+                throw DiscordChatExporterException.ChannelIsEmpty();
         }
     }
 }


### PR DESCRIPTION
Previously:
```
$ DiscordChatExporter.Cli exportguild [...]
Exporting 20 channels... 0,00 % %
Channel 'test1' contains no messages for the specified period.
Access is forbidden.
Access is forbidden.
Access is forbidden.
Channel 'test2' contains no messages for the specified period.
Access is forbidden.
Successfully exported 4 channel(s).
```

Now:
```
$ DiscordChatExporter.Cli exportguild [...]
Exporting 20 channels... 0,00 % %
Channel 'test1': No messages for the specified period.
Channel 'private1': Access is forbidden.
Channel 'private2': Access is forbidden.
Channel 'private3': Access is forbidden.
Channel 'test2': No messages for the specified period.
Channel 'private4': Access is forbidden.
Successfully exported 4 channel(s).
```

Fixes #451

P.S. Sorry but I don't seem to have the C#9 compiler yet :sweat_smile: 