### PR TITLE
[JSON] Don't escape Unicode characters when possible

### DIFF
--- a/DiscordChatExporter.Domain/Exporting/Writers/JsonMessageWriter.cs
+++ b/DiscordChatExporter.Domain/Exporting/Writers/JsonMessageWriter.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
+using System.Text.Encodings.Web;
 using DiscordChatExporter.Domain.Discord.Models;
 using DiscordChatExporter.Domain.Exporting.Writers.MarkdownVisitors;
 using DiscordChatExporter.Domain.Internal.Extensions;
@@ -19,6 +20,7 @@ namespace DiscordChatExporter.Domain.Exporting.Writers
         {
             _writer = new Utf8JsonWriter(stream, new JsonWriterOptions
             {
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
                 Indented = true
             });
         }


### PR DESCRIPTION
This was more straightforward than expected :)

Previously:
```json
  "channel": {
    "id": "286894854376783882",
    "type": "GuildTextChat",
    "category": "Text",
    "name": "oznameni-announcements",
    "topic": "Zde se stru\u010Dn\u011B dozv\u00EDte o v\u0161em d\u016Fle\u017Eit\u00E9m: akce, \u010Dl\u00E1nky, zm\u011Bny..."
  },
```
Now:
```json
  "channel": {
    "id": "286894854376783882",
    "type": "GuildTextChat",
    "category": "Text",
    "name": "oznameni-announcements",
    "topic": "Zde se stručně dozvíte o všem důležitém: akce, články, změny..."
  },
```


Fixes #450.