### PR TITLE
Fix grammar in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,7 @@
 
 **Project status: active**.
 
-DiscordChatExporter can be used to export message history from a [Discord](https://discord.com) channel to a file. It works with direct messages, group messages, server channels, supports Discord's dialect of markdown and all other rich media features.
+DiscordChatExporter can be used to export message history from a [Discord](https://discord.com) channel to a file. It works with direct messages, group messages, and server channels, and supports Discord's dialect of markdown as well as all other rich media features.
 
 **If you have questions or issues, please check out the [wiki](https://github.com/Tyrrrz/DiscordChatExporter/wiki)**.
 


### PR DESCRIPTION
I've made some changes to correct the syntax of this sentence.

The sentence describes articles that DiscordChatExporter (referred to by the pronoun 'it') works with. This includes 'direct messages', 'group messages', and 'server channels'. However, the fourth article breaks out of correct syntax since it does not fall under the domain of what DiscordChatExporter works with: instead, it adds a new clause to the sentence without a valid conjunction. 

Thus, to fix this, we first add a valid conjunction ('and') in between the two clauses, and we add an and after the third article of the first clause as per convention. Whereas using 'and' again to refer to other rich media features is not incorrect, I've chosen to replace the conjunction in order to make the sentence flow better after accounting for the corrections.