### PR TITLE
Fix crash on encountering invalid snowflake

### DIFF
--- a/DiscordChatExporter.Domain/Exporting/ExportContext.cs
+++ b/DiscordChatExporter.Domain/Exporting/ExportContext.cs
@@ -45,13 +45,13 @@ namespace DiscordChatExporter.Domain.Exporting
             var dateFormat => date.ToLocalString(dateFormat)
         };
 
-        public Member? TryGetMember(Snowflake? id) => Members.FirstOrDefault(m => m.Id == id);
+        public Member? TryGetMember(Snowflake id) => Members.FirstOrDefault(m => m.Id == id);
 
-        public Channel? TryGetChannel(Snowflake? id) => Channels.FirstOrDefault(c => c.Id == id);
+        public Channel? TryGetChannel(Snowflake id) => Channels.FirstOrDefault(c => c.Id == id);
 
-        public Role? TryGetRole(Snowflake? id) => Roles.FirstOrDefault(r => r.Id == id);
+        public Role? TryGetRole(Snowflake id) => Roles.FirstOrDefault(r => r.Id == id);
 
-        public Color? TryGetUserColor(Snowflake? id)
+        public Color? TryGetUserColor(Snowflake id)
         {
             var member = TryGetMember(id);
             var roles = member?.RoleIds.Join(Roles, i => i, r => r.Id, (_, role) => role);

--- a/DiscordChatExporter.Domain/Exporting/ExportContext.cs
+++ b/DiscordChatExporter.Domain/Exporting/ExportContext.cs
@@ -45,13 +45,13 @@ namespace DiscordChatExporter.Domain.Exporting
             var dateFormat => date.ToLocalString(dateFormat)
         };
 
-        public Member? TryGetMember(Snowflake id) => Members.FirstOrDefault(m => m.Id == id);
+        public Member? TryGetMember(Snowflake? id) => Members.FirstOrDefault(m => m.Id == id);
 
-        public Channel? TryGetChannel(Snowflake id) => Channels.FirstOrDefault(c => c.Id == id);
+        public Channel? TryGetChannel(Snowflake? id) => Channels.FirstOrDefault(c => c.Id == id);
 
-        public Role? TryGetRole(Snowflake id) => Roles.FirstOrDefault(r => r.Id == id);
+        public Role? TryGetRole(Snowflake? id) => Roles.FirstOrDefault(r => r.Id == id);
 
-        public Color? TryGetUserColor(Snowflake id)
+        public Color? TryGetUserColor(Snowflake? id)
         {
             var member = TryGetMember(id);
             var roles = member?.RoleIds.Join(Roles, i => i, r => r.Id, (_, role) => role);

--- a/DiscordChatExporter.Domain/Exporting/Writers/MarkdownVisitors/HtmlMarkdownVisitor.cs
+++ b/DiscordChatExporter.Domain/Exporting/Writers/MarkdownVisitors/HtmlMarkdownVisitor.cs
@@ -7,6 +7,7 @@ using DiscordChatExporter.Domain.Discord;
 using DiscordChatExporter.Domain.Discord.Models;
 using DiscordChatExporter.Domain.Markdown;
 using DiscordChatExporter.Domain.Markdown.Ast;
+using DiscordChatExporter.Domain.Utilities;
 
 namespace DiscordChatExporter.Domain.Exporting.Writers.MarkdownVisitors
 {
@@ -76,6 +77,7 @@ namespace DiscordChatExporter.Domain.Exporting.Writers.MarkdownVisitors
 
         protected override MarkdownNode VisitMention(MentionNode mention)
         {
+            var mentionId = Snowflake.TryParse(mention.Id);
             if (mention.Type == MentionType.Meta)
             {
                 _buffer
@@ -85,7 +87,7 @@ namespace DiscordChatExporter.Domain.Exporting.Writers.MarkdownVisitors
             }
             else if (mention.Type == MentionType.User)
             {
-                var member = _context.TryGetMember(Snowflake.TryParse(mention.Id));
+                var member = mentionId?.Pipe(_context.TryGetMember);
                 var fullName = member?.User.FullName ?? "Unknown";
                 var nick = member?.Nick ?? "Unknown";
 
@@ -96,7 +98,7 @@ namespace DiscordChatExporter.Domain.Exporting.Writers.MarkdownVisitors
             }
             else if (mention.Type == MentionType.Channel)
             {
-                var channel = _context.TryGetChannel(Snowflake.TryParse(mention.Id));
+                var channel = mentionId?.Pipe(_context.TryGetChannel);
                 var name = channel?.Name ?? "deleted-channel";
 
                 _buffer
@@ -106,7 +108,7 @@ namespace DiscordChatExporter.Domain.Exporting.Writers.MarkdownVisitors
             }
             else if (mention.Type == MentionType.Role)
             {
-                var role = _context.TryGetRole(Snowflake.TryParse(mention.Id));
+                var role = mentionId?.Pipe(_context.TryGetRole);
                 var name = role?.Name ?? "deleted-role";
                 var color = role?.Color;
 

--- a/DiscordChatExporter.Domain/Exporting/Writers/MarkdownVisitors/HtmlMarkdownVisitor.cs
+++ b/DiscordChatExporter.Domain/Exporting/Writers/MarkdownVisitors/HtmlMarkdownVisitor.cs
@@ -85,7 +85,7 @@ namespace DiscordChatExporter.Domain.Exporting.Writers.MarkdownVisitors
             }
             else if (mention.Type == MentionType.User)
             {
-                var member = _context.TryGetMember(Snowflake.Parse(mention.Id));
+                var member = _context.TryGetMember(Snowflake.TryParse(mention.Id));
                 var fullName = member?.User.FullName ?? "Unknown";
                 var nick = member?.Nick ?? "Unknown";
 
@@ -96,7 +96,7 @@ namespace DiscordChatExporter.Domain.Exporting.Writers.MarkdownVisitors
             }
             else if (mention.Type == MentionType.Channel)
             {
-                var channel = _context.TryGetChannel(Snowflake.Parse(mention.Id));
+                var channel = _context.TryGetChannel(Snowflake.TryParse(mention.Id));
                 var name = channel?.Name ?? "deleted-channel";
 
                 _buffer
@@ -106,7 +106,7 @@ namespace DiscordChatExporter.Domain.Exporting.Writers.MarkdownVisitors
             }
             else if (mention.Type == MentionType.Role)
             {
-                var role = _context.TryGetRole(Snowflake.Parse(mention.Id));
+                var role = _context.TryGetRole(Snowflake.TryParse(mention.Id));
                 var name = role?.Name ?? "deleted-role";
                 var color = role?.Color;
 

--- a/DiscordChatExporter.Domain/Exporting/Writers/MarkdownVisitors/PlainTextMarkdownVisitor.cs
+++ b/DiscordChatExporter.Domain/Exporting/Writers/MarkdownVisitors/PlainTextMarkdownVisitor.cs
@@ -2,6 +2,7 @@
 using DiscordChatExporter.Domain.Discord;
 using DiscordChatExporter.Domain.Markdown;
 using DiscordChatExporter.Domain.Markdown.Ast;
+using DiscordChatExporter.Domain.Utilities;
 
 namespace DiscordChatExporter.Domain.Exporting.Writers.MarkdownVisitors
 {
@@ -24,27 +25,28 @@ namespace DiscordChatExporter.Domain.Exporting.Writers.MarkdownVisitors
 
         protected override MarkdownNode VisitMention(MentionNode mention)
         {
+            var mentionId = Snowflake.TryParse(mention.Id);
             if (mention.Type == MentionType.Meta)
             {
                 _buffer.Append($"@{mention.Id}");
             }
             else if (mention.Type == MentionType.User)
             {
-                var member = _context.TryGetMember(Snowflake.TryParse(mention.Id));
+                var member = mentionId?.Pipe(_context.TryGetMember);
                 var name = member?.User.Name ?? "Unknown";
 
                 _buffer.Append($"@{name}");
             }
             else if (mention.Type == MentionType.Channel)
             {
-                var channel = _context.TryGetChannel(Snowflake.TryParse(mention.Id));
+                var channel = mentionId?.Pipe(_context.TryGetChannel);
                 var name = channel?.Name ?? "deleted-channel";
 
                 _buffer.Append($"#{name}");
             }
             else if (mention.Type == MentionType.Role)
             {
-                var role = _context.TryGetRole(Snowflake.TryParse(mention.Id));
+                var role = mentionId?.Pipe(_context.TryGetRole);
                 var name = role?.Name ?? "deleted-role";
 
                 _buffer.Append($"@{name}");

--- a/DiscordChatExporter.Domain/Exporting/Writers/MarkdownVisitors/PlainTextMarkdownVisitor.cs
+++ b/DiscordChatExporter.Domain/Exporting/Writers/MarkdownVisitors/PlainTextMarkdownVisitor.cs
@@ -30,21 +30,21 @@ namespace DiscordChatExporter.Domain.Exporting.Writers.MarkdownVisitors
             }
             else if (mention.Type == MentionType.User)
             {
-                var member = _context.TryGetMember(Snowflake.Parse(mention.Id));
+                var member = _context.TryGetMember(Snowflake.TryParse(mention.Id));
                 var name = member?.User.Name ?? "Unknown";
 
                 _buffer.Append($"@{name}");
             }
             else if (mention.Type == MentionType.Channel)
             {
-                var channel = _context.TryGetChannel(Snowflake.Parse(mention.Id));
+                var channel = _context.TryGetChannel(Snowflake.TryParse(mention.Id));
                 var name = channel?.Name ?? "deleted-channel";
 
                 _buffer.Append($"#{name}");
             }
             else if (mention.Type == MentionType.Role)
             {
-                var role = _context.TryGetRole(Snowflake.Parse(mention.Id));
+                var role = _context.TryGetRole(Snowflake.TryParse(mention.Id));
                 var name = role?.Name ?? "deleted-role";
 
                 _buffer.Append($"@{name}");


### PR DESCRIPTION
Closes #474, closes #478 (same bug)

Currently, the exporter crashes if a message contains a mention with an invalidly formatted ID. In the case of an ID with valid that cannot be resolved, it correctly replaces it with #deleted-channel, #deleted-role, or #deleted-user, depending on the scenario (e.g. `<@236257776421175296>` will print as `@deleted-user` but `<#1>` will crash the program). This PR simply fixes this bug by extending the behaviour so that unresolvable snowflakes appear the same regardless of whether they are valid or not - this is the way Discord displays them.

The specific code change was simply to replace some references to `Snowflake.Parse` with `Snowflake.TryParse`. The "TryGet" methods for identifying snowflakes in the `ExportContext` class were also modified to accept `Snowflake?` instead of `Snowflake` as an input parameter to handle null cases.