### PR TITLE
[CLI] Fix sorting by channel/category position

### DIFF
--- a/DiscordChatExporter.Cli/Commands/GetChannelsCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/GetChannelsCommand.cs
@@ -4,6 +4,7 @@ using CliFx;
 using CliFx.Attributes;
 using DiscordChatExporter.Cli.Commands.Base;
 using DiscordChatExporter.Domain.Discord;
+using DiscordChatExporter.Domain.Discord.Models.Common;
 using DiscordChatExporter.Domain.Utilities;
 
 namespace DiscordChatExporter.Cli.Commands
@@ -18,7 +19,7 @@ namespace DiscordChatExporter.Cli.Commands
         {
             var channels = await GetDiscordClient().GetGuildChannelsAsync(GuildId);
 
-            foreach (var channel in channels.OrderBy(c => c.Category).ThenBy(c => c.Name))
+            foreach (var channel in channels.OrderBy(c => c.Category, PositionBasedComparer.Instance).ThenBy(c => c.Name))
                 console.Output.WriteLine($"{channel.Id} | {channel.Category} / {channel.Name}");
         }
     }

--- a/DiscordChatExporter.Cli/Commands/GetDirectMessageChannelsCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/GetDirectMessageChannelsCommand.cs
@@ -4,6 +4,7 @@ using CliFx;
 using CliFx.Attributes;
 using DiscordChatExporter.Cli.Commands.Base;
 using DiscordChatExporter.Domain.Discord.Models;
+using DiscordChatExporter.Domain.Discord.Models.Common;
 using DiscordChatExporter.Domain.Utilities;
 
 namespace DiscordChatExporter.Cli.Commands
@@ -15,7 +16,7 @@ namespace DiscordChatExporter.Cli.Commands
         {
             var channels = await GetDiscordClient().GetGuildChannelsAsync(Guild.DirectMessages.Id);
 
-            foreach (var channel in channels.OrderBy(c => c.Category).ThenBy(c => c.Name))
+            foreach (var channel in channels.OrderBy(c => c.Category, PositionBasedComparer.Instance).ThenBy(c => c.Name))
                 console.Output.WriteLine($"{channel.Id} | {channel.Category} / {channel.Name}");
         }
     }

--- a/DiscordChatExporter.Domain/Discord/Models/Channel.cs
+++ b/DiscordChatExporter.Domain/Discord/Models/Channel.cs
@@ -22,7 +22,7 @@ namespace DiscordChatExporter.Domain.Discord.Models
     }
 
     // https://discord.com/developers/docs/resources/channel#channel-object
-    public partial class Channel : IHasId
+    public partial class Channel : IHasIdAndPosition
     {
         public Snowflake Id { get; }
 

--- a/DiscordChatExporter.Domain/Discord/Models/ChannelCategory.cs
+++ b/DiscordChatExporter.Domain/Discord/Models/ChannelCategory.cs
@@ -8,7 +8,7 @@ using Tyrrrz.Extensions;
 
 namespace DiscordChatExporter.Domain.Discord.Models
 {
-    public partial class ChannelCategory : IHasId
+    public partial class ChannelCategory : IHasIdAndPosition
     {
         public Snowflake Id { get; }
 

--- a/DiscordChatExporter.Domain/Discord/Models/Common/ChannelPositionBasedComparer.cs
+++ b/DiscordChatExporter.Domain/Discord/Models/Common/ChannelPositionBasedComparer.cs
@@ -2,29 +2,29 @@
 
 namespace DiscordChatExporter.Domain.Discord.Models.Common
 {
-    public partial class ChannelPositionBasedComparer : IComparer<Channel>
+    public partial class PositionBasedComparer : IComparer<IHasIdAndPosition>
     {
-        public int Compare(Channel? x, Channel? y)
+        public int Compare(IHasIdAndPosition? x, IHasIdAndPosition? y)
         {
             int result;
             if (x != null)
             {
                 result = x.Position.CompareTo(y?.Position);
-            }
-            else if (y != null)
-            {
-                result = -y.Position.CompareTo(x?.Position);
+                if(result == 0)
+                {
+                    result = x.Id.Value.CompareTo(y?.Id.Value);
+                }
             }
             else
             {
-                result = 0;
+                result = y == null ? 0 : -1;
             }
             return result;
         }
     }
 
-    public partial class ChannelPositionBasedComparer
+    public partial class PositionBasedComparer
     {
-        public static ChannelPositionBasedComparer Instance { get; } = new();
+        public static PositionBasedComparer Instance { get; } = new();
     }
 }

--- a/DiscordChatExporter.Domain/Discord/Models/Common/IHasIdAndPosition.cs
+++ b/DiscordChatExporter.Domain/Discord/Models/Common/IHasIdAndPosition.cs
@@ -1,0 +1,7 @@
+﻿namespace DiscordChatExporter.Domain.Discord.Models.Common
+{
+    public interface IHasIdAndPosition : IHasId
+    {
+        int Position { get; }
+    }
+}


### PR DESCRIPTION
Fixes a bug introduced by #472. The unused `ChannelBasedPositionComparer` was replaced with a more generic `PositionBasedComparer`, which now correctly sorts first by position and then by ID. `IHasIdAndPosition : IHasId` was created to facilitate this, and applied to both `Channel` and `ChannelCategory`. The new comparer was used in the CLI's `dm` and `channels` commands to stop them from throwing exceptions.