### PR TITLE
[CLI] Fix missing channel category bug when API returns empty string

### DIFF
--- a/DiscordChatExporter.Domain/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Domain/Discord/DiscordClient.cs
@@ -176,9 +176,13 @@ namespace DiscordChatExporter.Domain.Discord
                 var response = await GetJsonResponseAsync($"channels/{channelId}");
                 return ChannelCategory.Parse(response);
             }
+            /***
+             * In some cases, the Discord API returns an empty body when requesting some channel category info.
+             * Instead, we use an empty channel category as a fallback.
+             */
             catch (DiscordChatExporterException)
             {
-                return ChannelCategory.Empty();
+                return ChannelCategory.Empty;
             }
 
         }

--- a/DiscordChatExporter.Domain/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Domain/Discord/DiscordClient.cs
@@ -176,7 +176,7 @@ namespace DiscordChatExporter.Domain.Discord
                 var response = await GetJsonResponseAsync($"channels/{channelId}");
                 return ChannelCategory.Parse(response);
             }
-            catch (DiscordChatExporterException exception)
+            catch (DiscordChatExporterException)
             {
                 return ChannelCategory.Empty();
             }

--- a/DiscordChatExporter.Domain/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Domain/Discord/DiscordClient.cs
@@ -171,9 +171,16 @@ namespace DiscordChatExporter.Domain.Discord
 
         public async ValueTask<ChannelCategory> GetChannelCategoryAsync(Snowflake channelId)
         {
-            var response = await GetJsonResponseAsync($"channels/{channelId}");
+            try
+            {
+                var response = await GetJsonResponseAsync($"channels/{channelId}");
+                return ChannelCategory.Parse(response);
+            }
+            catch (DiscordChatExporterException exception)
+            {
+                return ChannelCategory.Empty();
+            }
 
-            return ChannelCategory.Parse(response);
         }
 
         public async ValueTask<Channel> GetChannelAsync(Snowflake channelId)

--- a/DiscordChatExporter.Domain/Discord/Models/ChannelCategory.cs
+++ b/DiscordChatExporter.Domain/Discord/Models/ChannelCategory.cs
@@ -44,5 +44,10 @@ namespace DiscordChatExporter.Domain.Discord.Models
                 position.Value
             );
         }
+
+        public static ChannelCategory Empty()
+        {
+            return new (Snowflake.Zero, "Missing", 0);
+        }
     }
 }

--- a/DiscordChatExporter.Domain/Discord/Models/ChannelCategory.cs
+++ b/DiscordChatExporter.Domain/Discord/Models/ChannelCategory.cs
@@ -45,9 +45,6 @@ namespace DiscordChatExporter.Domain.Discord.Models
             );
         }
 
-        public static ChannelCategory Empty()
-        {
-            return new (Snowflake.Zero, "Missing", 0);
-        }
+        public static ChannelCategory Empty { get; } = new(Snowflake.Zero, "Missing", 0);
     }
 }


### PR DESCRIPTION
This fixes the issue mentionned here:

Fixes #426
Fixes #464

It seems that in some cases, the Discord API returns an empty body when requesting some channel category info, throwing an exception and ultimately failing the extraction process. This is a simple fix that catches this event and replaces the Category with a default, empty category. There might be some more involved approaches to this issue but this makes it usable for me and it might help someone else.