### PR TITLE
Skip JSON Validation

### DIFF
--- a/DiscordChatExporter.Domain/Exporting/Writers/JsonMessageWriter.cs
+++ b/DiscordChatExporter.Domain/Exporting/Writers/JsonMessageWriter.cs
@@ -21,7 +21,8 @@ namespace DiscordChatExporter.Domain.Exporting.Writers
             _writer = new Utf8JsonWriter(stream, new JsonWriterOptions
             {
                 Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-                Indented = true
+                Indented = true,
+                SkipValidation = true
             });
         }
 


### PR DESCRIPTION
Closes #413 

Tiny modification to turn off validation of JSON output as discussed in the linked issue. The motivation is to prevent exceptions from being thrown during disposal of the JSON writer and hiding other exceptions.