### PR TITLE
Fix JSON discriminator and nickname fields

### DIFF
--- a/DiscordChatExporter.Core/Discord/Data/User.cs
+++ b/DiscordChatExporter.Core/Discord/Data/User.cs
@@ -15,9 +15,11 @@ namespace DiscordChatExporter.Core.Discord.Data
 
         public int Discriminator { get; }
 
+        public string DiscriminatorFormatted => $"{Discriminator:0000}";
+
         public string Name { get; }
 
-        public string FullName => $"{Name}#{Discriminator:0000}";
+        public string FullName => $"{Name}#{DiscriminatorFormatted}";
 
         public string AvatarUrl { get; }
 

--- a/DiscordChatExporter.Core/Exporting/Writers/JsonMessageWriter.cs
+++ b/DiscordChatExporter.Core/Exporting/Writers/JsonMessageWriter.cs
@@ -169,7 +169,7 @@ namespace DiscordChatExporter.Core.Exporting.Writers
 
             _writer.WriteString("id", mentionedUser.Id.ToString());
             _writer.WriteString("name", mentionedUser.Name);
-            _writer.WriteNumber("discriminator", mentionedUser.Discriminator);
+            _writer.WriteString("discriminator", $"{mentionedUser.Discriminator:0000}");
             _writer.WriteString("nickname", Context.TryGetMember(mentionedUser.Id)?.Nick ?? mentionedUser.Name);
             _writer.WriteBoolean("isBot", mentionedUser.IsBot);
 
@@ -229,6 +229,7 @@ namespace DiscordChatExporter.Core.Exporting.Writers
             _writer.WriteString("id", message.Author.Id.ToString());
             _writer.WriteString("name", message.Author.Name);
             _writer.WriteString("discriminator", $"{message.Author.Discriminator:0000}");
+            _writer.WriteString("nickname", Context.TryGetMember(message.Author.Id)?.Nick ?? message.Author.Name);
             _writer.WriteBoolean("isBot", message.Author.IsBot);
             _writer.WriteString("avatarUrl", await Context.ResolveMediaUrlAsync(message.Author.AvatarUrl));
             _writer.WriteEndObject();

--- a/DiscordChatExporter.Core/Exporting/Writers/JsonMessageWriter.cs
+++ b/DiscordChatExporter.Core/Exporting/Writers/JsonMessageWriter.cs
@@ -169,7 +169,7 @@ namespace DiscordChatExporter.Core.Exporting.Writers
 
             _writer.WriteString("id", mentionedUser.Id.ToString());
             _writer.WriteString("name", mentionedUser.Name);
-            _writer.WriteString("discriminator", $"{mentionedUser.Discriminator:0000}");
+            _writer.WriteString("discriminator", mentionedUser.DiscriminatorFormatted);
             _writer.WriteString("nickname", Context.TryGetMember(mentionedUser.Id)?.Nick ?? mentionedUser.Name);
             _writer.WriteBoolean("isBot", mentionedUser.IsBot);
 
@@ -228,7 +228,7 @@ namespace DiscordChatExporter.Core.Exporting.Writers
             _writer.WriteStartObject("author");
             _writer.WriteString("id", message.Author.Id.ToString());
             _writer.WriteString("name", message.Author.Name);
-            _writer.WriteString("discriminator", $"{message.Author.Discriminator:0000}");
+            _writer.WriteString("discriminator", message.Author.DiscriminatorFormatted);
             _writer.WriteString("nickname", Context.TryGetMember(message.Author.Id)?.Nick ?? message.Author.Name);
             _writer.WriteBoolean("isBot", message.Author.IsBot);
             _writer.WriteString("avatarUrl", await Context.ResolveMediaUrlAsync(message.Author.AvatarUrl));


### PR DESCRIPTION
Closes #500 

Tiny fix to address discriminators with leading zeroes not printing correctly in mentions as well as missing nickname fields in author objects. It was suggested in the linked issue to create a method to handle outputting user objects to the JSON since the code in the two locations is nearly identical (and that was the cause of the issue), but I decided to wait until further input was given before moving forward with that. The differences in the two areas are: 1. mention objects have no property name since they reside in an array and 2. `avatarUrl` is added to author objects but not mentions. Is this enough to warrant separation of the code, or could a method be made with some parameters to handle those differences?