### PR TITLE
Add a raw json export format

### DIFF
--- a/DiscordChatExporter.Core/Exporting/ExportFormat.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportFormat.cs
@@ -8,7 +8,8 @@ namespace DiscordChatExporter.Core.Exporting
         HtmlDark,
         HtmlLight,
         Csv,
-        Json
+        Json,
+        JsonRaw
     }
 
     public static class ExportFormatExtensions
@@ -20,6 +21,7 @@ namespace DiscordChatExporter.Core.Exporting
             ExportFormat.HtmlLight => "html",
             ExportFormat.Csv => "csv",
             ExportFormat.Json => "json",
+            ExportFormat.JsonRaw => "json",
             _ => throw new ArgumentOutOfRangeException(nameof(format))
         };
 
@@ -30,6 +32,7 @@ namespace DiscordChatExporter.Core.Exporting
             ExportFormat.HtmlLight => "HTML (Light)",
             ExportFormat.Csv => "CSV",
             ExportFormat.Json => "JSON",
+            ExportFormat.JsonRaw => "JSON (no-formatting)",
             _ => throw new ArgumentOutOfRangeException(nameof(format))
         };
     }

--- a/DiscordChatExporter.Core/Exporting/MessageExporter.cs
+++ b/DiscordChatExporter.Core/Exporting/MessageExporter.cs
@@ -116,6 +116,7 @@ namespace DiscordChatExporter.Core.Exporting
                 ExportFormat.HtmlDark => new HtmlMessageWriter(stream, context, "Dark"),
                 ExportFormat.HtmlLight => new HtmlMessageWriter(stream, context, "Light"),
                 ExportFormat.Json => new JsonMessageWriter(stream, context),
+                ExportFormat.JsonRaw => new JsonRawMessageWriter(stream, context),
                 _ => throw new ArgumentOutOfRangeException(nameof(format), $"Unknown export format '{format}'.")
             };
         }

--- a/DiscordChatExporter.Core/Exporting/Writers/JsonMessageWriter.cs
+++ b/DiscordChatExporter.Core/Exporting/Writers/JsonMessageWriter.cs
@@ -26,7 +26,7 @@ namespace DiscordChatExporter.Core.Exporting.Writers
             });
         }
 
-        private string FormatMarkdown(string? markdown) =>
+        protected virtual string FormatMarkdown(string? markdown) =>
             PlainTextMarkdownVisitor.Format(Context, markdown ?? "");
 
         private async ValueTask WriteAttachmentAsync(Attachment attachment)

--- a/DiscordChatExporter.Core/Exporting/Writers/JsonRawMessageWriter.cs
+++ b/DiscordChatExporter.Core/Exporting/Writers/JsonRawMessageWriter.cs
@@ -7,6 +7,5 @@ namespace DiscordChatExporter.Core.Exporting.Writers
         public JsonRawMessageWriter(Stream stream, ExportContext context) : base(stream, context) {}
 
         protected override string FormatMarkdown(string? markdown) => markdown ?? "";
-
     }
 }

--- a/DiscordChatExporter.Core/Exporting/Writers/JsonRawMessageWriter.cs
+++ b/DiscordChatExporter.Core/Exporting/Writers/JsonRawMessageWriter.cs
@@ -1,0 +1,12 @@
+﻿using System.IO;
+
+namespace DiscordChatExporter.Core.Exporting.Writers
+{
+    internal class JsonRawMessageWriter : JsonMessageWriter
+    {
+        public JsonRawMessageWriter(Stream stream, ExportContext context) : base(stream, context) {}
+
+        protected override string FormatMarkdown(string? markdown) => markdown ?? "";
+
+    }
+}


### PR DESCRIPTION
This adds a JSON export format that doesn't parse any of the markdown just exports the raw data allowing for better post-processing outside the exporter.