### PR TITLE
Fix emojis not being downloaded with json

### DIFF
--- a/DiscordChatExporter.Core/Exporting/Writers/MarkdownVisitors/PlainTextMarkdownVisitor.cs
+++ b/DiscordChatExporter.Core/Exporting/Writers/MarkdownVisitors/PlainTextMarkdownVisitor.cs
@@ -57,6 +57,16 @@ namespace DiscordChatExporter.Core.Exporting.Writers.MarkdownVisitors
 
         protected override MarkdownNode VisitEmoji(EmojiNode emoji)
         {
+            // Force the emoji to be downloaded if needed
+            if (emoji.IsAnimated)
+            {
+                _context.ResolveMediaUrlAsync($"https://cdn.discordapp.com/emojis/{emoji.Id}.gif");
+            }
+            else
+            {
+                _context.ResolveMediaUrlAsync($"https://cdn.discordapp.com/emojis/{emoji.Id}.png");
+            }
+
             _buffer.Append(
                 emoji.IsCustomEmoji
                     ? $":{emoji.Name}:"


### PR DESCRIPTION
This fixes an issue where emojis that are not used in reactions don't get downloaded with a JSON export.