### PR TITLE
Escape brackets in category name

### DIFF
--- a/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
+++ b/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
@@ -14,6 +14,7 @@ using DiscordChatExporter.Core.Exceptions;
 using DiscordChatExporter.Core.Exporting;
 using DiscordChatExporter.Core.Exporting.Partitioning;
 using DiscordChatExporter.Core.Utils.Extensions;
+using Spectre.Console;
 using Tyrrrz.Extensions;
 
 namespace DiscordChatExporter.Cli.Commands.Base
@@ -64,7 +65,7 @@ namespace DiscordChatExporter.Cli.Commands.Base
                     // Export
                     try
                     {
-                        await progressContext.StartTaskAsync($"{channel.Category} / {channel.Name}", async progress =>
+                        await progressContext.StartTaskAsync(Markup.Escape($"{channel.Category} / {channel.Name}"), async progress =>
                         {
                             var guild = await Discord.GetGuildAsync(channel.GuildId);
 


### PR DESCRIPTION
Closes #557 

Small bugfix to address a crash that occurs when a category name contains brackets and gets intepreted as a markup string by Spectre. This is fixed by using Spectre's `Markup.Escape()` before passing a description to the progress task.