### PR TITLE
Render YouTube iframe for applicable video embeds

### DIFF
--- a/DiscordChatExporter.Core/Exporting/Writers/Html/Core.css
+++ b/DiscordChatExporter.Core/Exporting/Writers/Html/Core.css
@@ -458,6 +458,10 @@ img {
     border-radius: 3px;
 }
 
+.chatlog__embed-youtube-container {
+    margin-top: 0.6em;
+}
+
 .chatlog__embed-image-container {
     margin-top: 0.6em;
 }

--- a/DiscordChatExporter.Core/Exporting/Writers/Html/MessageGroupTemplate.cshtml
+++ b/DiscordChatExporter.Core/Exporting/Writers/Html/MessageGroupTemplate.cshtml
@@ -220,7 +220,7 @@
                                         if (embed.Thumbnail is not null && !string.IsNullOrWhiteSpace(embed.Thumbnail.Url))
                                         {
                                             <div class="chatlog__embed-youtube-container">
-                                                <iframe class="chatlog__embed-youtube" width="400" height="225"
+                                                <iframe class="chatlog__embed-youtube" width="400" height="225" frameBorder="0" style="border-radius: 5px"
                                                         src="@embed.Url.Replace("/watch?v=", "/embed/")">
                                                 </iframe>
                                             </div>

--- a/DiscordChatExporter.Core/Exporting/Writers/Html/MessageGroupTemplate.cshtml
+++ b/DiscordChatExporter.Core/Exporting/Writers/Html/MessageGroupTemplate.cshtml
@@ -214,20 +214,15 @@
                                             }
                                         </div>
                                     }
-                                    @if (!string.IsNullOrWhiteSpace(embed.Url))
+                                    @if (!string.IsNullOrWhiteSpace(embed.Url) && embed.Url.IndexOf("youtube.com/watch?v=") != -1)
                                     {
-                                        if (embed.Url.IndexOf("youtube.com/watch?v=") != -1)
+
+                                        if (embed.Thumbnail is not null && !string.IsNullOrWhiteSpace(embed.Thumbnail.Url))
                                         {
                                             <div class="chatlog__embed-youtube-container">
                                                 <iframe class="chatlog__embed-youtube" width="400" height="225"
                                                         src="@embed.Url.Replace("/watch?v=", "/embed/")">
                                                 </iframe>
-                                            </div>
-                                        }
-                                        else if (!string.IsNullOrWhiteSpace(embed.Description))
-                                        {
-                                            <div class="chatlog__embed-description">
-                                                <div class="markdown preserve-whitespace">@Raw(FormatEmbedMarkdown(embed.Description))</div>
                                             </div>
                                         }
                                     }
@@ -267,18 +262,7 @@
 
                                 @if (embed.Thumbnail is not null && !string.IsNullOrWhiteSpace(embed.Thumbnail.Url))
                                 {
-                                    if (!string.IsNullOrWhiteSpace(embed.Url))
-                                    {
-                                        if (embed.Url.IndexOf("youtube.com/watch?v=") == -1)
-                                        {
-                                            <div class="chatlog__embed-thumbnail-container">
-                                                <a class="chatlog__embed-thumbnail-link" href="@await ResolveUrlAsync(embed.Thumbnail.ProxyUrl ?? embed.Thumbnail.Url)">
-                                                    <img class="chatlog__embed-thumbnail" src="@await ResolveUrlAsync(embed.Thumbnail.ProxyUrl ?? embed.Thumbnail.Url)" alt="Thumbnail">
-                                                </a>
-                                            </div>
-                                        }
-                                    }
-                                    else
+                                    if (string.IsNullOrWhiteSpace(embed.Url) || embed.Url.IndexOf("youtube.com/watch?v=") == -1)
                                     {
                                         <div class="chatlog__embed-thumbnail-container">
                                             <a class="chatlog__embed-thumbnail-link" href="@await ResolveUrlAsync(embed.Thumbnail.ProxyUrl ?? embed.Thumbnail.Url)">

--- a/DiscordChatExporter.Core/Exporting/Writers/Html/MessageGroupTemplate.cshtml
+++ b/DiscordChatExporter.Core/Exporting/Writers/Html/MessageGroupTemplate.cshtml
@@ -214,8 +214,24 @@
                                             }
                                         </div>
                                     }
-
-                                    @if (!string.IsNullOrWhiteSpace(embed.Description))
+                                    @if (!string.IsNullOrWhiteSpace(embed.Url))
+                                    {
+                                        if (embed.Url.IndexOf("youtube.com/watch?v=") != -1)
+                                        {
+                                            <div class="chatlog__embed-youtube-container">
+                                                <iframe class="chatlog__embed-youtube" width="400" height="225"
+                                                        src="@embed.Url.Replace("/watch?v=", "/embed/")">
+                                                </iframe>
+                                            </div>
+                                        }
+                                        else if (!string.IsNullOrWhiteSpace(embed.Description))
+                                        {
+                                            <div class="chatlog__embed-description">
+                                                <div class="markdown preserve-whitespace">@Raw(FormatEmbedMarkdown(embed.Description))</div>
+                                            </div>
+                                        }
+                                    }
+                                    else if (!string.IsNullOrWhiteSpace(embed.Description))
                                     {
                                         <div class="chatlog__embed-description">
                                             <div class="markdown preserve-whitespace">@Raw(FormatEmbedMarkdown(embed.Description))</div>
@@ -251,11 +267,25 @@
 
                                 @if (embed.Thumbnail is not null && !string.IsNullOrWhiteSpace(embed.Thumbnail.Url))
                                 {
-                                    <div class="chatlog__embed-thumbnail-container">
-                                        <a class="chatlog__embed-thumbnail-link" href="@await ResolveUrlAsync(embed.Thumbnail.ProxyUrl ?? embed.Thumbnail.Url)">
-                                            <img class="chatlog__embed-thumbnail" src="@await ResolveUrlAsync(embed.Thumbnail.ProxyUrl ?? embed.Thumbnail.Url)" alt="Thumbnail">
-                                        </a>
-                                    </div>
+                                    if (!string.IsNullOrWhiteSpace(embed.Url))
+                                    {
+                                        if (embed.Url.IndexOf("youtube.com/watch?v=") == -1)
+                                        {
+                                            <div class="chatlog__embed-thumbnail-container">
+                                                <a class="chatlog__embed-thumbnail-link" href="@await ResolveUrlAsync(embed.Thumbnail.ProxyUrl ?? embed.Thumbnail.Url)">
+                                                    <img class="chatlog__embed-thumbnail" src="@await ResolveUrlAsync(embed.Thumbnail.ProxyUrl ?? embed.Thumbnail.Url)" alt="Thumbnail">
+                                                </a>
+                                            </div>
+                                        }
+                                    }
+                                    else
+                                    {
+                                        <div class="chatlog__embed-thumbnail-container">
+                                            <a class="chatlog__embed-thumbnail-link" href="@await ResolveUrlAsync(embed.Thumbnail.ProxyUrl ?? embed.Thumbnail.Url)">
+                                                <img class="chatlog__embed-thumbnail" src="@await ResolveUrlAsync(embed.Thumbnail.ProxyUrl ?? embed.Thumbnail.Url)" alt="Thumbnail">
+                                            </a>
+                                        </div>
+                                    }
                                 }
                             </div>
 


### PR DESCRIPTION
[Original Issue](https://github.com/Tyrrrz/DiscordChatExporter/issues/570)
Replace the typical youtube link "/watch?v=" with "/embed/" and instead of showing the video description, make it show the video iframe embed instead. 
This solution wouldn't work with shortened or different weird youtube URL formats, but works for the general case.

**Result**
![image](https://user-images.githubusercontent.com/73214439/122049746-9e07d000-cd97-11eb-91d1-f13635e392f1.png)


Closes #570