### PR TITLE
Download user profile pictures at a higher resolution

### DIFF
--- a/DiscordChatExporter.Core/Discord/Data/User.cs
+++ b/DiscordChatExporter.Core/Discord/Data/User.cs
@@ -53,7 +53,7 @@ namespace DiscordChatExporter.Core.Discord.Data
                 ? "gif"
                 : "png";
 
-            return $"https://cdn.discordapp.com/avatars/{id}/{avatarHash}.{extension}?size=40";
+            return $"https://cdn.discordapp.com/avatars/{id}/{avatarHash}.{extension}?size=128";
         }
 
         public static User Parse(JsonElement json)


### PR DESCRIPTION
In my opinion, it would be better to download profile images at a larger 128x128 resolution for archival purposes. As far as I can tell, there shouldn't be any CSS changes needed.

<!--

**Important:**

Please make sure that there is an existing issue that describes the problem solved by your pull request. If there isn't one, consider creating it first.
An open issue offers a good place to iron out requirements, discuss possible solutions, and ask questions.

Remember to also:

- Keep your pull request focused and as small as possible. If you want to contribute multiple unrelated changes, please create separate pull requests for them.
- Follow the coding style and conventions already established by the project. When in doubt about which style to use, ask in the comments to your pull request.
- If you want to start a discussion regarding a specific change you've made, add a review comment to your own code. This can be used to highlight something important or to seek further input from others.

-->

<!-- Please specify the issue addressed by this pull request -->
Closes #655 