### PR TITLE
Fix for extremely long file extensions

### DIFF
--- a/DiscordChatExporter.Core/Exporting/MediaDownloader.cs
+++ b/DiscordChatExporter.Core/Exporting/MediaDownloader.cs
@@ -105,6 +105,7 @@ internal partial class MediaDownloader
         var fileExtension = Path.GetExtension(fileName);
         
         // Probably not a file extension, just a dot in a long file name
+        // https://github.com/Tyrrrz/DiscordChatExporter/issues/708
         if (fileExtension.Length > 41)
         {
             fileNameWithoutExtension = fileName;

--- a/DiscordChatExporter.Core/Exporting/MediaDownloader.cs
+++ b/DiscordChatExporter.Core/Exporting/MediaDownloader.cs
@@ -103,6 +103,13 @@ internal partial class MediaDownloader
         // Otherwise, use the original file name but inject the hash in the middle
         var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fileName);
         var fileExtension = Path.GetExtension(fileName);
+        
+        // Probably not a file extension, just a dot in a long file name
+        if (fileExtension.Length > 41)
+        {
+            fileNameWithoutExtension = fileName;
+            fileExtension = "";
+        }
 
         return PathEx.EscapeFileName(fileNameWithoutExtension.Truncate(42) + '-' + urlHash + fileExtension);
     }


### PR DESCRIPTION
This fixes a bug where file names containing a dot with a long string after it would get wrongly split into a file name and a file extension, which could (due to file extensions not being truncated) cause a System.IO.PathTooLongException when the file gets created.
(The number 41 was chosen because 40 is one of the longest extensions used in practice that I was able to find, +1 for the dot.)

This was the main cause of issue #708 (I am friends with the OP and we worked on tracking it down), and while it is still technically possible to reach a file path that's too long for a given system, it should no longer happen by accident in normal use cases after this fix.