### PR TITLE
Use 512x512 user profile pictures

### DIFF
--- a/DiscordChatExporter.Core/Discord/Data/User.cs
+++ b/DiscordChatExporter.Core/Discord/Data/User.cs
@@ -30,7 +30,7 @@ public partial record User
             ? "gif"
             : "png";
 
-        return $"https://cdn.discordapp.com/avatars/{id}/{avatarHash}.{extension}?size=128";
+        return $"https://cdn.discordapp.com/avatars/{id}/{avatarHash}.{extension}?size=512";
     }
 
     public static User Parse(JsonElement json)

--- a/DiscordChatExporter.Core/Exporting/Writers/Html/PreambleTemplate.cshtml
+++ b/DiscordChatExporter.Core/Exporting/Writers/Html/PreambleTemplate.cshtml
@@ -293,12 +293,14 @@
             width: 40px;
             height: 40px;
             margin-right: 16px;
+            image-rendering: high-quality;
         }
 
         .chatlog__author-avatar {
             border-radius: 50%;
             width: 40px;
             height: 40px;
+            image-rendering: high-quality;
         }
 
         .chatlog__messages {

--- a/DiscordChatExporter.Core/Exporting/Writers/Html/PreambleTemplate.cshtml
+++ b/DiscordChatExporter.Core/Exporting/Writers/Html/PreambleTemplate.cshtml
@@ -293,7 +293,6 @@
             width: 40px;
             height: 40px;
             margin-right: 16px;
-            image-rendering: high-quality;
         }
 
         .chatlog__author-avatar {


### PR DESCRIPTION
It *may* be a bit overkill, but user profile pictures should be saved at a high quality for archival purposes.

Improves #685 and fixes #655 for good.