### PR TITLE
Add has:pin filter

### DIFF
--- a/DiscordChatExporter.Core/Exporting/Filtering/HasMessageFilter.cs
+++ b/DiscordChatExporter.Core/Exporting/Filtering/HasMessageFilter.cs
@@ -19,6 +19,7 @@ internal class HasMessageFilter : MessageFilter
         MessageContentMatchKind.Video => message.Attachments.Any(file => file.IsVideo),
         MessageContentMatchKind.Image => message.Attachments.Any(file => file.IsImage),
         MessageContentMatchKind.Sound => message.Attachments.Any(file => file.IsAudio),
+        MessageContentMatchKind.Pin => message.IsPinned,
         _ => throw new InvalidOperationException($"Unknown message content match kind '{_kind}'.")
     };
 }

--- a/DiscordChatExporter.Core/Exporting/Filtering/MessageContentMatchKind.cs
+++ b/DiscordChatExporter.Core/Exporting/Filtering/MessageContentMatchKind.cs
@@ -7,5 +7,6 @@ internal enum MessageContentMatchKind
     File,
     Video,
     Image,
-    Sound
+    Sound,
+    Pin
 }

--- a/DiscordChatExporter.Core/Exporting/Filtering/Parsing/FilterGrammar.cs
+++ b/DiscordChatExporter.Core/Exporting/Filtering/Parsing/FilterGrammar.cs
@@ -58,7 +58,8 @@ internal static class FilterGrammar
             Span.EqualToIgnoreCase("file").IgnoreThen(Parse.Return(MessageContentMatchKind.File)),
             Span.EqualToIgnoreCase("video").IgnoreThen(Parse.Return(MessageContentMatchKind.Video)),
             Span.EqualToIgnoreCase("image").IgnoreThen(Parse.Return(MessageContentMatchKind.Image)),
-            Span.EqualToIgnoreCase("sound").IgnoreThen(Parse.Return(MessageContentMatchKind.Sound))
+            Span.EqualToIgnoreCase("sound").IgnoreThen(Parse.Return(MessageContentMatchKind.Sound)),
+            Span.EqualToIgnoreCase("pin").IgnoreThen(Parse.Return(MessageContentMatchKind.Pin))
         ))
         .Select(k => (MessageFilter) new HasMessageFilter(k))
         .Named("has:<value>");


### PR DESCRIPTION
Closes #845.

Adds a new `has:*` filter, `has:pin`.
The filter filters for messages that are pinned.

Example: In a test DM channel, there is only one pinned message, with the text content `test`. There are many other non-pinned messages.

An export of the entire channel with the filter expression of `has:pin` results in the following output, which consists only of that one pinned message:

![image](https://user-images.githubusercontent.com/9027551/168951647-6168d5c7-cd5a-4a06-a73c-4ddebb02ea5e.png)

Please let me know if I understood the feature request correctly.


