### PR TITLE
Update guide to direct users to the Advanced section of Discord settings rather than appearance

### DIFF
--- a/DiscordChatExporter.Cli/Commands/GuideCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/GuideCommand.cs
@@ -42,7 +42,7 @@ public class GuideCommand : ICommand
 
         console.Output.WriteLine(" 1. Open Discord");
         console.Output.WriteLine(" 2. Open Settings");
-        console.Output.WriteLine(" 3. Go to Appearance section");
+        console.Output.WriteLine(" 3. Go to Advanced section");
         console.Output.WriteLine(" 4. Enable Developer Mode");
         console.Output.WriteLine(" 5. Right click on the desired guild or channel and click Copy ID");
         console.Output.WriteLine();


### PR DESCRIPTION
Very small PR that is largely self-explanatory.  Developer Mode is now enabled via Advanced settings rather than in the Appearance tab, and I wanted to save other users the same confusion I had.