### PR TITLE
Expand tilde to home directory on *nix systems in output path

### DIFF
--- a/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
+++ b/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
@@ -20,12 +20,21 @@ namespace DiscordChatExporter.Cli.Commands.Base;
 
 public abstract class ExportCommandBase : TokenCommandBase
 {
+    private string _outputPath = Directory.GetCurrentDirectory();
+
     [CommandOption(
         "output",
         'o',
         Description = "Output file or directory path."
     )]
-    public string OutputPath { get; init; } = Directory.GetCurrentDirectory();
+    public string OutputPath
+    {
+        get => _outputPath;
+        init
+        {
+            _outputPath = Path.GetFullPath(value);
+        }
+    }
 
     [CommandOption(
         "format",

--- a/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
+++ b/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
@@ -30,10 +30,9 @@ public abstract class ExportCommandBase : TokenCommandBase
     public string OutputPath
     {
         get => _outputPath;
-        init
-        {
-            _outputPath = Path.GetFullPath(value);
-        }
+        // Handle ~/ in paths on *nix systems
+        // https://github.com/Tyrrrz/DiscordChatExporter/pull/903
+        init => _outputPath = Path.GetFullPath(value);
     }
 
     [CommandOption(


### PR DESCRIPTION
<!--

**Important:**

Please make sure that there is an existing issue that describes the problem solved by your pull request. If there isn't one, consider creating it first.
An open issue offers a good place to iron out requirements, discuss possible solutions, and ask questions.

Remember to also:

- Keep your pull request focused and as small as possible. If you want to contribute multiple unrelated changes, please create separate pull requests for each of them.
- Follow the coding style and conventions already established by the project. When in doubt about which style to use, ask in the comments to your pull request.
- If you want to start a discussion regarding a specific change you've made, add a review comment to your own code. This can be used to highlight something important or to seek further input from others.

-->

<!-- Please specify the issue addressed by this pull request -->
<!-- Closes #ISSUE_NUMBER -->

When specifying the output path like this `~/Documents/exportpath` new directories will be created in the current directory instead of using the correct path.

This PR fixes this issue by replacing "~" on non windows systems with the home directory for the output path.
I'm not quite happy with this solution yet, since I had to create a new private attribute and adapt the `OutputPath` property accordingly.
Also I think using `Replace()` for this operation might just be okay, but doesn't feel clean at all.
But it seems like .NET has no cross-platform pathlib library to handle this easily. Although a cleaner solution could be reached by using [this library](https://github.com/nemec/pathlib) for handling paths instead.

As a first time contributor I didn't want to include any new dependencies, so I chose to initially go with the first solution.

Let me know what you think and tell me if you want me to make further changes.