### PR TITLE
Support GIF embeds when exporting to HTML

### DIFF
--- a/DiscordChatExporter.Core/Discord/Data/Embeds/Embed.cs
+++ b/DiscordChatExporter.Core/Discord/Data/Embeds/Embed.cs
@@ -32,7 +32,7 @@ public partial record Embed(
     public YouTubeVideoEmbedProjection? TryGetYouTubeVideo() =>
         YouTubeVideoEmbedProjection.TryResolve(this);
 
-    public GifvEmbedProjection? TryGetGifvEmbed() =>
+    public GifvEmbedProjection? TryGetGifv() =>
         GifvEmbedProjection.TryResolve(this);
 }
 

--- a/DiscordChatExporter.Core/Discord/Data/Embeds/Embed.cs
+++ b/DiscordChatExporter.Core/Discord/Data/Embeds/Embed.cs
@@ -19,6 +19,7 @@ public partial record Embed(
     IReadOnlyList<EmbedField> Fields,
     EmbedImage? Thumbnail,
     IReadOnlyList<EmbedImage> Images,
+    EmbedVideo? Video,
     EmbedFooter? Footer)
 {
     public PlainImageEmbedProjection? TryGetPlainImage() =>
@@ -29,6 +30,9 @@ public partial record Embed(
 
     public YouTubeVideoEmbedProjection? TryGetYouTubeVideo() =>
         YouTubeVideoEmbedProjection.TryResolve(this);
+
+    public TenorEmbedProjection? TryGetTenorEmbed() =>
+        TenorEmbedProjection.TryResolve(this);
 }
 
 public partial record Embed
@@ -59,6 +63,8 @@ public partial record Embed
             json.GetPropertyOrNull("image")?.Pipe(EmbedImage.Parse).Enumerate().ToArray() ??
             Array.Empty<EmbedImage>();
 
+        var video = json.GetPropertyOrNull("video")?.Pipe(EmbedVideo.Parse);
+
         var footer = json.GetPropertyOrNull("footer")?.Pipe(EmbedFooter.Parse);
 
         return new Embed(
@@ -71,6 +77,7 @@ public partial record Embed
             fields,
             thumbnail,
             images,
+            video,
             footer
         );
     }

--- a/DiscordChatExporter.Core/Discord/Data/Embeds/Embed.cs
+++ b/DiscordChatExporter.Core/Discord/Data/Embeds/Embed.cs
@@ -11,6 +11,7 @@ namespace DiscordChatExporter.Core.Discord.Data.Embeds;
 // https://discord.com/developers/docs/resources/channel#embed-object
 public partial record Embed(
     string? Title,
+    string? Type,
     string? Url,
     DateTimeOffset? Timestamp,
     Color? Color,
@@ -31,8 +32,8 @@ public partial record Embed(
     public YouTubeVideoEmbedProjection? TryGetYouTubeVideo() =>
         YouTubeVideoEmbedProjection.TryResolve(this);
 
-    public TenorEmbedProjection? TryGetTenorEmbed() =>
-        TenorEmbedProjection.TryResolve(this);
+    public GifvEmbedProjection? TryGetGifvEmbed() =>
+        GifvEmbedProjection.TryResolve(this);
 }
 
 public partial record Embed
@@ -40,6 +41,7 @@ public partial record Embed
     public static Embed Parse(JsonElement json)
     {
         var title = json.GetPropertyOrNull("title")?.GetStringOrNull();
+        var type = json.GetPropertyOrNull("type")?.GetStringOrNull();
         var url = json.GetPropertyOrNull("url")?.GetNonWhiteSpaceStringOrNull();
         var timestamp = json.GetPropertyOrNull("timestamp")?.GetDateTimeOffset();
         var color = json.GetPropertyOrNull("color")?.GetInt32OrNull()?.Pipe(System.Drawing.Color.FromArgb).ResetAlpha();
@@ -69,6 +71,7 @@ public partial record Embed
 
         return new Embed(
             title,
+            type,
             url,
             timestamp,
             color,

--- a/DiscordChatExporter.Core/Discord/Data/Embeds/EmbedVideo.cs
+++ b/DiscordChatExporter.Core/Discord/Data/Embeds/EmbedVideo.cs
@@ -6,16 +6,16 @@ namespace DiscordChatExporter.Core.Discord.Data.Embeds;
 // https://discord.com/developers/docs/resources/channel#embed-object-embed-video-structure
 public record EmbedVideo(
     string? Url,
+    string? ProxyUrl
     int? Width,
-    int? Height,
-    string? ProxyUrl)
+    int? Height)
 {
     public static EmbedVideo Parse(JsonElement json)
     {
         var url = json.GetPropertyOrNull("url")?.GetNonWhiteSpaceStringOrNull();
+        var proxyUrl = json.GetPropertyOrNull("proxy_url")?.GetNonWhiteSpaceStringOrNull();
         var width = json.GetPropertyOrNull("width")?.GetInt32OrNull();
         var height = json.GetPropertyOrNull("height")?.GetInt32OrNull();
-        var proxyUrl = json.GetPropertyOrNull("proxy_url")?.GetNonWhiteSpaceStringOrNull();
 
         return new EmbedVideo(url, width, height, proxyUrl);
     }

--- a/DiscordChatExporter.Core/Discord/Data/Embeds/EmbedVideo.cs
+++ b/DiscordChatExporter.Core/Discord/Data/Embeds/EmbedVideo.cs
@@ -9,7 +9,6 @@ public record EmbedVideo(
     int? Width,
     int? Height,
     string? ProxyUrl)
-
 {
     public static EmbedVideo Parse(JsonElement json)
     {

--- a/DiscordChatExporter.Core/Discord/Data/Embeds/EmbedVideo.cs
+++ b/DiscordChatExporter.Core/Discord/Data/Embeds/EmbedVideo.cs
@@ -6,7 +6,7 @@ namespace DiscordChatExporter.Core.Discord.Data.Embeds;
 // https://discord.com/developers/docs/resources/channel#embed-object-embed-video-structure
 public record EmbedVideo(
     string? Url,
-    string? ProxyUrl
+    string? ProxyUrl,
     int? Width,
     int? Height)
 {

--- a/DiscordChatExporter.Core/Discord/Data/Embeds/EmbedVideo.cs
+++ b/DiscordChatExporter.Core/Discord/Data/Embeds/EmbedVideo.cs
@@ -17,6 +17,6 @@ public record EmbedVideo(
         var width = json.GetPropertyOrNull("width")?.GetInt32OrNull();
         var height = json.GetPropertyOrNull("height")?.GetInt32OrNull();
 
-        return new EmbedVideo(url, width, height, proxyUrl);
+        return new EmbedVideo(url, proxyUrl, width, height);
     }
 }

--- a/DiscordChatExporter.Core/Discord/Data/Embeds/EmbedVideo.cs
+++ b/DiscordChatExporter.Core/Discord/Data/Embeds/EmbedVideo.cs
@@ -1,0 +1,23 @@
+using JsonExtensions.Reading;
+using System.Text.Json;
+
+namespace DiscordChatExporter.Core.Discord.Data.Embeds;
+
+// https://discord.com/developers/docs/resources/channel#embed-object-embed-video-structure
+public record EmbedVideo(
+    string? Url,
+    int? Width,
+    int? Height,
+    string? ProxyUrl)
+
+{
+    public static EmbedVideo Parse(JsonElement json)
+    {
+        var url = json.GetPropertyOrNull("url")?.GetNonWhiteSpaceStringOrNull();
+        var width = json.GetPropertyOrNull("width")?.GetInt32OrNull();
+        var height = json.GetPropertyOrNull("height")?.GetInt32OrNull();
+        var proxyUrl = json.GetPropertyOrNull("proxy_url")?.GetNonWhiteSpaceStringOrNull();
+
+        return new EmbedVideo(url, width, height, proxyUrl);
+    }
+}

--- a/DiscordChatExporter.Core/Discord/Data/Embeds/GifvEmbedProjection.cs
+++ b/DiscordChatExporter.Core/Discord/Data/Embeds/GifvEmbedProjection.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.RegularExpressions;
 
 namespace DiscordChatExporter.Core.Discord.Data.Embeds;
@@ -12,7 +13,7 @@ public partial record GifvEmbedProjection(string Url)
         if (embed.Video is null || string.IsNullOrWhiteSpace(embed.Video.Url))
             return null;
 
-        if (embed.Type != "gifv")
+        if (!string.Equals(embed.Type, "gifv", StringComparison.OrdinalIgnoreCase))
             return null;
 
         return new GifvEmbedProjection(embed.Url);

--- a/DiscordChatExporter.Core/Discord/Data/Embeds/GifvEmbedProjection.cs
+++ b/DiscordChatExporter.Core/Discord/Data/Embeds/GifvEmbedProjection.cs
@@ -2,9 +2,9 @@ using System.Text.RegularExpressions;
 
 namespace DiscordChatExporter.Core.Discord.Data.Embeds;
 
-public partial record TenorEmbedProjection(string Url)
+public partial record GifvEmbedProjection(string Url)
 {
-    public static TenorEmbedProjection? TryResolve(Embed embed)
+    public static GifvEmbedProjection? TryResolve(Embed embed)
     {
         if (string.IsNullOrWhiteSpace(embed.Url))
             return null;
@@ -12,10 +12,9 @@ public partial record TenorEmbedProjection(string Url)
         if (embed.Video is null || string.IsNullOrWhiteSpace(embed.Video.Url))
             return null;
 
-        // Has to be a vaild Tenor URL
-        if (!Regex.IsMatch(embed.Url, @"tenor\.com/view/[\w-]+$"))
+        if (embed.Type != "gifv")
             return null;
 
-        return new TenorEmbedProjection(embed.Url);
+        return new GifvEmbedProjection(embed.Url);
     }
 }

--- a/DiscordChatExporter.Core/Discord/Data/Embeds/TenorEmbedProjection.cs
+++ b/DiscordChatExporter.Core/Discord/Data/Embeds/TenorEmbedProjection.cs
@@ -1,0 +1,23 @@
+using System.Text.RegularExpressions;
+
+namespace DiscordChatExporter.Core.Discord.Data.Embeds;
+
+public partial record TenorEmbedProjection(string Url)
+{
+
+    public static TenorEmbedProjection? TryResolve(Embed embed)
+    {
+        if (string.IsNullOrWhiteSpace(embed.Url))
+            return null;
+
+        // Needs a the mp4 video URL linked in them embed json
+        if (embed.Video is null || string.IsNullOrWhiteSpace(embed.Video.Url))
+            return null;
+
+        // Has to be a vaild Tenor URL
+        if (!Regex.IsMatch(embed.Url, @"tenor\.com/view/[\w-]+$"))
+            return null;
+
+        return new TenorEmbedProjection(embed.Url);
+    }
+}

--- a/DiscordChatExporter.Core/Discord/Data/Embeds/TenorEmbedProjection.cs
+++ b/DiscordChatExporter.Core/Discord/Data/Embeds/TenorEmbedProjection.cs
@@ -9,7 +9,6 @@ public partial record TenorEmbedProjection(string Url)
         if (string.IsNullOrWhiteSpace(embed.Url))
             return null;
 
-        // Needs a the mp4 video URL linked in them embed json
         if (embed.Video is null || string.IsNullOrWhiteSpace(embed.Video.Url))
             return null;
 

--- a/DiscordChatExporter.Core/Discord/Data/Embeds/TenorEmbedProjection.cs
+++ b/DiscordChatExporter.Core/Discord/Data/Embeds/TenorEmbedProjection.cs
@@ -4,7 +4,6 @@ namespace DiscordChatExporter.Core.Discord.Data.Embeds;
 
 public partial record TenorEmbedProjection(string Url)
 {
-
     public static TenorEmbedProjection? TryResolve(Embed embed)
     {
         if (string.IsNullOrWhiteSpace(embed.Url))

--- a/DiscordChatExporter.Core/Exporting/Writers/Html/MessageGroupTemplate.cshtml
+++ b/DiscordChatExporter.Core/Exporting/Writers/Html/MessageGroupTemplate.cshtml
@@ -232,7 +232,7 @@
                         @if (embed.Video is not null && !string.IsNullOrWhiteSpace(embed.Video.Url) && embed.Thumbnail is not null)
                         {
                             <div class="chatlog__attachment">
-                                <video class="chatlog__attachment-media" poster="@await ResolveUrlAsync(embed.Thumbnail.ProxyUrl ?? embed.Thumbnail.Url ?? "")" loop="" preload="auto" aria-label="GIF" width="@(embed.Video.Width)" height="@(embed.Video.Height)" autoplay="">
+                                <video class="chatlog__attachment-media" poster="@await ResolveUrlAsync(embed.Thumbnail.ProxyUrl ?? embed.Thumbnail.Url)" loop="" preload="auto" aria-label="GIF" width="@(embed.Video.Width)" height="@(embed.Video.Height)" autoplay="">
                                     <source src="@await ResolveUrlAsync(embed.Video.ProxyUrl ?? embed.Video.Url)" alt="@(embed.Description ?? "Tenor GIF")" title="@embed.Title">
                                 </video>                            
                             </div>

--- a/DiscordChatExporter.Core/Exporting/Writers/Html/MessageGroupTemplate.cshtml
+++ b/DiscordChatExporter.Core/Exporting/Writers/Html/MessageGroupTemplate.cshtml
@@ -209,7 +209,7 @@
                 @foreach (var embed in message.Embeds)
                 {
                     // Gifv embed
-                    if (embed.TryGetGifvEmbed() is { } gifvEmbed)
+                    if (embed.TryGetGifv() is { } gifvEmbed)
                     {
                         @if (embed.Video is not null && !string.IsNullOrWhiteSpace(embed.Video.Url) && embed.Thumbnail is not null)
                         {

--- a/DiscordChatExporter.Core/Exporting/Writers/Html/MessageGroupTemplate.cshtml
+++ b/DiscordChatExporter.Core/Exporting/Writers/Html/MessageGroupTemplate.cshtml
@@ -232,9 +232,7 @@
                         @if (embed.Video is not null && !string.IsNullOrWhiteSpace(embed.Video.Url) && embed.Thumbnail is not null)
                         {
                             <div class="chatlog__attachment">
-                                <video class="chatlog__attachment-media" poster="@await ResolveUrlAsync(embed.Thumbnail.ProxyUrl ?? embed.Thumbnail.Url ?? "")" loop="" preload="none" aria-label="GIF" width="@(embed.Video.Width)" height="@(embed.Video.Height)" autoplay="">
-                                    <source src="@await ResolveUrlAsync(embed.Video.ProxyUrl ?? embed.Video.Url)" alt="@(embed.Description ?? "Tenor GIF")" title="@embed.Title">
-                                </video>                            
+                                <video class="chatlog__attachment-media" poster="@await ResolveUrlAsync(embed.Thumbnail.ProxyUrl ?? embed.Thumbnail.Url ?? "")" src="@await ResolveUrlAsync(embed.Video.ProxyUrl ?? embed.Video.Url)" loop="" preload="none" aria-label="GIF" width="@(embed.Video.Width)" height="@(embed.Video.Height)" autoplay=""/>                           
                             </div>
                         }
                     }

--- a/DiscordChatExporter.Core/Exporting/Writers/Html/MessageGroupTemplate.cshtml
+++ b/DiscordChatExporter.Core/Exporting/Writers/Html/MessageGroupTemplate.cshtml
@@ -226,6 +226,18 @@
                             </div>
                         </div>
                     }
+                    // Tenor embed
+                    else if (embed.TryGetTenorEmbed() is { } tenorEmbed)
+                    {
+                        @if (embed.Video is not null && !string.IsNullOrWhiteSpace(embed.Video.Url) && embed.Thumbnail is not null)
+                        {
+                            <div class="chatlog__attachment">
+                                <video class="chatlog__attachment-media" poster="@await ResolveUrlAsync(embed.Thumbnail.ProxyUrl ?? embed.Thumbnail.Url ?? "")" loop="" preload="none" aria-label="GIF" width="@(embed.Video.Width)" height="@(embed.Video.Height)" autoplay="">
+                                    <source src="@await ResolveUrlAsync(embed.Video.ProxyUrl ?? embed.Video.Url)" alt="@(embed.Description ?? "Tenor GIF")" title="@embed.Title">
+                                </video>                            
+                            </div>
+                        }
+                    }
                     // YouTube embed
                     else if (embed.TryGetYouTubeVideo() is { } youTubeVideoEmbed)
                     {

--- a/DiscordChatExporter.Core/Exporting/Writers/Html/MessageGroupTemplate.cshtml
+++ b/DiscordChatExporter.Core/Exporting/Writers/Html/MessageGroupTemplate.cshtml
@@ -208,8 +208,20 @@
                 @{/* Embeds */}
                 @foreach (var embed in message.Embeds)
                 {
+                    // Gifv embed
+                    if (embed.TryGetGifvEmbed() is { } gifvEmbed)
+                    {
+                        @if (embed.Video is not null && !string.IsNullOrWhiteSpace(embed.Video.Url) && embed.Thumbnail is not null)
+                        {
+                            <div class="chatlog__attachment">
+                                <video class="chatlog__attachment-media" poster="@await ResolveUrlAsync(embed.Thumbnail.ProxyUrl ?? embed.Thumbnail.Url)" loop="" controls="" aria-label="GIF" width="@(embed.Video.Width)" height="@(embed.Video.Height)">
+                                    <source src="@await ResolveUrlAsync(embed.Video.ProxyUrl ?? embed.Video.Url)" alt="@(embed.Description ?? "Tenor GIF")" title="@embed.Title">
+                                </video>                            
+                            </div>
+                        }
+                    }
                     // Plain image embed
-                    if (embed.TryGetPlainImage() is { } plainImageEmbed)
+                    else if (embed.TryGetPlainImage() is { } plainImageEmbed)
                     {
                         <div class="chatlog__embed">
                             <a href="@await ResolveUrlAsync(plainImageEmbed.Url)">
@@ -225,18 +237,6 @@
                                 <iframe class="chatlog__embed-spotify" src="@spotifyTrackEmbed.Url" width="400" height="80" allowtransparency="true" allow="encrypted-media"></iframe>
                             </div>
                         </div>
-                    }
-                    // Tenor embed
-                    else if (embed.TryGetTenorEmbed() is { } tenorEmbed)
-                    {
-                        @if (embed.Video is not null && !string.IsNullOrWhiteSpace(embed.Video.Url) && embed.Thumbnail is not null)
-                        {
-                            <div class="chatlog__attachment">
-                                <video class="chatlog__attachment-media" poster="@await ResolveUrlAsync(embed.Thumbnail.ProxyUrl ?? embed.Thumbnail.Url)" loop="" controls="" aria-label="GIF" width="@(embed.Video.Width)" height="@(embed.Video.Height)">
-                                    <source src="@await ResolveUrlAsync(embed.Video.ProxyUrl ?? embed.Video.Url)" alt="@(embed.Description ?? "Tenor GIF")" title="@embed.Title">
-                                </video>                            
-                            </div>
-                        }
                     }
                     // YouTube embed
                     else if (embed.TryGetYouTubeVideo() is { } youTubeVideoEmbed)

--- a/DiscordChatExporter.Core/Exporting/Writers/Html/MessageGroupTemplate.cshtml
+++ b/DiscordChatExporter.Core/Exporting/Writers/Html/MessageGroupTemplate.cshtml
@@ -232,7 +232,7 @@
                         @if (embed.Video is not null && !string.IsNullOrWhiteSpace(embed.Video.Url) && embed.Thumbnail is not null)
                         {
                             <div class="chatlog__attachment">
-                                <video class="chatlog__attachment-media" poster="@await ResolveUrlAsync(embed.Thumbnail.ProxyUrl ?? embed.Thumbnail.Url)" loop="" preload="auto" aria-label="GIF" width="@(embed.Video.Width)" height="@(embed.Video.Height)" autoplay="">
+                                <video class="chatlog__attachment-media" poster="@await ResolveUrlAsync(embed.Thumbnail.ProxyUrl ?? embed.Thumbnail.Url)" loop="" controls="" aria-label="GIF" width="@(embed.Video.Width)" height="@(embed.Video.Height)">
                                     <source src="@await ResolveUrlAsync(embed.Video.ProxyUrl ?? embed.Video.Url)" alt="@(embed.Description ?? "Tenor GIF")" title="@embed.Title">
                                 </video>                            
                             </div>

--- a/DiscordChatExporter.Core/Exporting/Writers/Html/MessageGroupTemplate.cshtml
+++ b/DiscordChatExporter.Core/Exporting/Writers/Html/MessageGroupTemplate.cshtml
@@ -232,7 +232,9 @@
                         @if (embed.Video is not null && !string.IsNullOrWhiteSpace(embed.Video.Url) && embed.Thumbnail is not null)
                         {
                             <div class="chatlog__attachment">
-                                <video class="chatlog__attachment-media" poster="@await ResolveUrlAsync(embed.Thumbnail.ProxyUrl ?? embed.Thumbnail.Url ?? "")" src="@await ResolveUrlAsync(embed.Video.ProxyUrl ?? embed.Video.Url)" loop="" preload="none" aria-label="GIF" width="@(embed.Video.Width)" height="@(embed.Video.Height)" autoplay=""/>                           
+                                <video class="chatlog__attachment-media" poster="@await ResolveUrlAsync(embed.Thumbnail.ProxyUrl ?? embed.Thumbnail.Url ?? "")" loop="" preload="auto" aria-label="GIF" width="@(embed.Video.Width)" height="@(embed.Video.Height)" autoplay="">
+                                    <source src="@await ResolveUrlAsync(embed.Video.ProxyUrl ?? embed.Video.Url)" alt="@(embed.Description ?? "Tenor GIF")" title="@embed.Title">
+                                </video>                            
                             </div>
                         }
                     }


### PR DESCRIPTION
<!--

**Important:**

Please make sure that there is an existing issue that describes the problem solved by your pull request. If there isn't one, consider creating it first.
An open issue offers a good place to iron out requirements, discuss possible solutions, and ask questions.

Remember to also:

- Keep your pull request focused and as small as possible. If you want to contribute multiple unrelated changes, please create separate pull requests for each of them.
- Follow the coding style and conventions already established by the project. When in doubt about which style to use, ask in the comments to your pull request.
- If you want to start a discussion regarding a specific change you've made, add a review comment to your own code. This can be used to highlight something important or to seek further input from others.

-->

<!-- Please specify the issue addressed by this pull request -->
Closes #683

This change will render tenor GIFs which are built into Discord the same way as Discord would render them. The GIFs are automatically played mp4 videos in a loop and the direct media link can be found in the JSON data provided by Discord.
![JSON](https://media.discordapp.net/attachments/869237617789648906/1016191326619975700/unknown.png)


Before the change:
![old](https://media.discordapp.net/attachments/554672804578983957/1017545052660187277/unknown.png)

After the change:
![new](https://media.discordapp.net/attachments/554672804578983957/1017544306141179904/unknown.png)
