### PR TITLE
Download emoji used in messages

### DIFF
--- a/DiscordChatExporter.Core/Exporting/Writers/Html/MessageGroupTemplate.cshtml
+++ b/DiscordChatExporter.Core/Exporting/Writers/Html/MessageGroupTemplate.cshtml
@@ -1,5 +1,6 @@
 @using System
 @using System.Linq
+@using System.Text.RegularExpressions;
 @using System.Threading.Tasks
 @using DiscordChatExporter.Core.Discord.Data
 @using DiscordChatExporter.Core.Discord.Data.Embeds
@@ -146,8 +147,24 @@
                         @{/* Text */}
                         @if (!isContentHidden)
                         {
-                            <span class="chatlog__markdown-preserve"><!--wmm:ignore-->@Raw(FormatMarkdown(message.Content))<!--/wmm:ignore--></span>
-                        }
+                            Regex regex = new Regex("(<img loading=\"lazy\" class=\"chatlog__emoji.+?src=\")([^\"]+)");
+                            var messageFormatted = FormatMarkdown(message.Content);
+                            var emojiURLs = regex.Matches(messageFormatted);
+
+                            foreach (Match matchedEmojiURL in emojiURLs)
+                            {
+                                var emojiURL = matchedEmojiURL.Groups[2].Value;
+                                if (string.IsNullOrEmpty(emojiURL))
+                                {
+                                    continue;   
+                                }
+
+                                Regex replacementRegex = new Regex($"(<img loading=\"lazy\" class=\"chatlog__emoji.+?src=\")({emojiURL})");
+
+                                messageFormatted = replacementRegex.Replace(messageFormatted, $"$1{await ResolveUrlAsync(emojiURL)}");
+                            }
+                            
+                            <span class="chatlog__markdown-preserve"><!--wmm:ignore-->@Raw(messageFormatted)<!--/wmm:ignore--></span>}
 
                         @{/* Edited timestamp */}
                         @if (message.EditedTimestamp is not null)

--- a/DiscordChatExporter.Core/Exporting/Writers/MarkdownVisitors/HtmlMarkdownVisitor.cs
+++ b/DiscordChatExporter.Core/Exporting/Writers/MarkdownVisitors/HtmlMarkdownVisitor.cs
@@ -123,7 +123,7 @@ internal partial class HtmlMarkdownVisitor : MarkdownVisitor
         var jumboClass = _isJumbo ? "chatlog__emoji--large" : "";
 
         _buffer
-            .Append($"<img loading=\"lazy\" class=\"chatlog__emoji {jumboClass}\" alt=\"{emoji.Name}\" title=\"{emoji.Code}\" src=\"{_context.ResolveMediaUrlAsync(emojiImageUrl)}\">");
+            .Append($"<img loading=\"lazy\" class=\"chatlog__emoji {jumboClass}\" alt=\"{emoji.Name}\" title=\"{emoji.Code}\" src=\"@await ResolveUrlAsync({emojiImageUrl})\">");
 
         return base.VisitEmoji(emoji);
     }

--- a/DiscordChatExporter.Core/Exporting/Writers/MarkdownVisitors/HtmlMarkdownVisitor.cs
+++ b/DiscordChatExporter.Core/Exporting/Writers/MarkdownVisitors/HtmlMarkdownVisitor.cs
@@ -123,7 +123,7 @@ internal partial class HtmlMarkdownVisitor : MarkdownVisitor
         var jumboClass = _isJumbo ? "chatlog__emoji--large" : "";
 
         _buffer
-            .Append($"<img loading=\"lazy\" class=\"chatlog__emoji {jumboClass}\" alt=\"{emoji.Name}\" title=\"{emoji.Code}\" src=\"@await ResolveUrlAsync({emojiImageUrl})\">");
+            .Append($"<img loading=\"lazy\" class=\"chatlog__emoji {jumboClass}\" alt=\"{emoji.Name}\" title=\"{emoji.Code}\" src=\"{emojiImageUrl}\">");
 
         return base.VisitEmoji(emoji);
     }

--- a/DiscordChatExporter.Core/Exporting/Writers/MarkdownVisitors/HtmlMarkdownVisitor.cs
+++ b/DiscordChatExporter.Core/Exporting/Writers/MarkdownVisitors/HtmlMarkdownVisitor.cs
@@ -123,7 +123,7 @@ internal partial class HtmlMarkdownVisitor : MarkdownVisitor
         var jumboClass = _isJumbo ? "chatlog__emoji--large" : "";
 
         _buffer
-            .Append($"<img loading=\"lazy\" class=\"chatlog__emoji {jumboClass}\" alt=\"{emoji.Name}\" title=\"{emoji.Code}\" src=\"{emojiImageUrl}\">");
+            .Append($"<img loading=\"lazy\" class=\"chatlog__emoji {jumboClass}\" alt=\"{emoji.Name}\" title=\"{emoji.Code}\" src=\"{_context.ResolveMediaUrlAsync(emojiImageUrl)}\">");
 
         return base.VisitEmoji(emoji);
     }


### PR DESCRIPTION
<!--

**Important:**

Please make sure that there is an existing issue that describes the problem solved by your pull request. If there isn't one, consider creating it first.
An open issue offers a good place to iron out requirements, discuss possible solutions, and ask questions.

Remember to also:

- Keep your pull request focused and as small as possible. If you want to contribute multiple unrelated changes, please create separate pull requests for each of them.
- Follow the coding style and conventions already established by the project. When in doubt about which style to use, ask in the comments to your pull request.
- If you want to start a discussion regarding a specific change you've made, add a review comment to your own code. This can be used to highlight something important or to seek further input from others.

-->

<!-- Please specify the issue addressed by this pull request -->
Closes #623

As discussed in the issue -> added ResolveMediaUrlAsync to download the emoji image if wanted by the context. Currently emojis are only downloaded if used in for reactions, but with this change you can also download emojis used in messages.
