### PR TITLE
Modify dockerfile to use non-root user

### DIFF
--- a/DiscordChatExporter.Cli.dockerfile
+++ b/DiscordChatExporter.Cli.dockerfile
@@ -12,7 +12,9 @@ RUN dotnet publish DiscordChatExporter.Cli -c Release -o ./publish
 # Run
 FROM mcr.microsoft.com/dotnet/runtime:6.0 AS run
 
-COPY --from=build ./publish ./
+COPY --from=build ./publish /opt/dce
 
-WORKDIR ./out
-ENTRYPOINT ["dotnet", "/DiscordChatExporter.Cli.dll"]
+RUN useradd dce
+USER dce
+WORKDIR /out
+ENTRYPOINT ["dotnet", "/opt/dce/DiscordChatExporter.Cli.dll"]


### PR DESCRIPTION
<!--

**Important:**

Please make sure that there is an existing issue that describes the problem solved by your pull request. If there isn't one, consider creating it first.
An open issue offers a good place to iron out requirements, discuss possible solutions, and ask questions.

Remember to also:

- Keep your pull request focused and as small as possible. If you want to contribute multiple unrelated changes, please create separate pull requests for each of them.
- Follow the coding style and conventions already established by the project. When in doubt about which style to use, ask in the comments to your pull request.
- If you want to start a discussion regarding a specific change you've made, add a review comment to your own code. This can be used to highlight something important or to seek further input from others.

-->

<!-- Please specify the issue addressed by this pull request -->
Closes #851 

Modifies the docker image so that the CLI is not run by default as root.
Furthermore, the docker usage instructions (Wiki) should be modified so that all run commands
get the following argument `--user (id -u)` with this, the image will be started as the current user.

E.g. `docker run --rm --user $(id -u) -v /home/$(whoami):/out tyrrrz/discordchatexporter:latest`
