### PR TITLE
Add --throttle command line argument

### DIFF
--- a/DiscordChatExporter.Cli/Commands/Base/TokenCommandBase.cs
+++ b/DiscordChatExporter.Cli/Commands/Base/TokenCommandBase.cs
@@ -27,8 +27,14 @@ public abstract class TokenCommandBase : ICommand
     )]
     public bool IsBotToken { get; init; }
 
+    [CommandOption(
+        "throttle",
+        Description = "Delay each api request (in miliseconds)."
+    )]
+    public int Throttle { get; init; } = 0;
+
     private DiscordClient? _discordClient;
-    protected DiscordClient Discord => _discordClient ??= new DiscordClient(Token);
+    protected DiscordClient Discord => _discordClient ??= new DiscordClient(Token, Throttle);
 
     public abstract ValueTask ExecuteAsync(IConsole console);
 }

--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -25,7 +25,7 @@ public class DiscordClient
 
     private TokenKind? _resolvedTokenKind;
 
-    public DiscordClient(string token, int throttle) => (_token, _throttle) = (token, throttle);
+    public DiscordClient(string token, int throttle = 0) => (_token, _throttle) = (token, throttle);
 
     private async ValueTask<HttpResponseMessage> GetResponseAsync(
         string url,

--- a/DiscordChatExporter.Gui/Services/SettingsService.cs
+++ b/DiscordChatExporter.Gui/Services/SettingsService.cs
@@ -16,6 +16,8 @@ public partial class SettingsService : SettingsManager
 
     public int ParallelLimit { get; set; } = 1;
 
+    public int Throttle { get; set; } = 0;
+
     public bool ShouldReuseAssets { get; set; }
 
     public string? LastToken { get; set; }

--- a/DiscordChatExporter.Gui/ViewModels/Components/DashboardViewModel.cs
+++ b/DiscordChatExporter.Gui/ViewModels/Components/DashboardViewModel.cs
@@ -101,7 +101,7 @@ public class DashboardViewModel : PropertyChangedBase
 
             _settingsService.LastToken = token;
 
-            var discord = new DiscordClient(token);
+            var discord = new DiscordClient(token, _settingsService.Throttle);
 
             var guildChannelMap = new Dictionary<Guild, IReadOnlyList<Channel>>();
             await foreach (var guild in discord.GetUserGuildsAsync())
@@ -156,6 +156,7 @@ public class DashboardViewModel : PropertyChangedBase
             if (await _dialogManager.ShowDialogAsync(dialog) != true)
                 return;
 
+            _discord.Throttle = _settingsService.Throttle;
             var exporter = new ChannelExporter(_discord);
 
             var progresses = Enumerable

--- a/DiscordChatExporter.Gui/ViewModels/Dialogs/SettingsViewModel.cs
+++ b/DiscordChatExporter.Gui/ViewModels/Dialogs/SettingsViewModel.cs
@@ -38,6 +38,12 @@ public class SettingsViewModel : DialogScreen
         set => _settingsService.ParallelLimit = Math.Clamp(value, 1, 10);
     }
 
+    public int Throttle
+    {
+        get => _settingsService.Throttle;
+        set => _settingsService.Throttle = Math.Max(0, value);
+    }
+
     public bool ShouldReuseAssets
     {
         get => _settingsService.ShouldReuseAssets;

--- a/DiscordChatExporter.Gui/Views/Dialogs/SettingsView.xaml
+++ b/DiscordChatExporter.Gui/Views/Dialogs/SettingsView.xaml
@@ -144,6 +144,23 @@
                                 Value="{Binding ParallelLimit}" />
                         </StackPanel>
                     </DockPanel>
+
+                    <!--  Throttle  -->
+                    <DockPanel
+                        Margin="16,8"
+                        Background="Transparent"
+                        LastChildFill="False"
+                        ToolTip="Delay each api request (in miliseconds)">
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            DockPanel.Dock="Left"
+                            Text="Delay requests (in ms)" />
+                        <TextBox
+                            Width="150"
+                            VerticalAlignment="Center"
+                            DockPanel.Dock="Right"
+                            Text="{Binding Throttle}" />
+                    </DockPanel>
                 </StackPanel>
             </ScrollViewer>
         </Border>


### PR DESCRIPTION
- Adds optional `--throttle <time_in_ms>` command line argument to delay each api call to Discord. 
- Delay is randomized time between <time_in_ms> and <time_in_ms>*2.
- Default is no throttle to keep backwards compatibility.

Example:
`--throttle 50` would delay each api call from 50 ms to 100 ms.

Why this change:
- The existing behaviour is to hit the API as frequently as it can and back off if it hits the api limit. This api limit would be frequently triggered on faster computers and internet connections closer to discord servers (low ping).
- This change would allow you to never hit api limit if you set high enough delay with tradeoff of slower export time.

Tested manually on command line version.
Closes no issue, because the project doesn't accept new feature requests.
