### PR TITLE
Use Alpine as the base image in docker, publish a self-contained app

### DIFF
--- a/DiscordChatExporter.Cli.dockerfile
+++ b/DiscordChatExporter.Cli.dockerfile
@@ -18,15 +18,15 @@ RUN dotnet publish DiscordChatExporter.Cli \
 # Run
 FROM mcr.microsoft.com/dotnet/runtime-deps:7.0-alpine
 
-RUN adduser \
+RUN mkdir -p /opt/discord_chat_exporter && \
+    adduser \
     --disabled-password \
     --no-create-home \
     dce
 USER dce
+COPY --from=build /build/publish /opt/discord_chat_exporter
 
-WORKDIR /opt/discord_chat_exporter
-
-COPY --from=build /build/publish ./
+WORKDIR /out
 
 ENV PATH="$PATH:/opt/discord_chat_exporter"
 ENTRYPOINT ["DiscordChatExporter.Cli"]

--- a/DiscordChatExporter.Cli.dockerfile
+++ b/DiscordChatExporter.Cli.dockerfile
@@ -19,8 +19,8 @@ RUN dotnet publish DiscordChatExporter.Cli \
 FROM mcr.microsoft.com/dotnet/runtime-deps:7.0-alpine
 
 # tzdata is needed for DateTimeOffset.ToLocalTime (for TimeZoneInfo.Local, to be precise)
-RUN apk add --no-cache tzdata && \
-    adduser \
+RUN apk add --no-cache tzdata
+RUN adduser \
     --disabled-password \
     --no-create-home \
     dce
@@ -32,5 +32,7 @@ COPY --from=build /build/publish /opt/discord_chat_exporter
 # changing it would break existing workflows.
 WORKDIR /out
 
+# Having it in PATH is convenient for interactive shell sessions,
+# which may be useful for debugging.
 ENV PATH="$PATH:/opt/discord_chat_exporter"
 ENTRYPOINT ["DiscordChatExporter.Cli"]

--- a/DiscordChatExporter.Cli.dockerfile
+++ b/DiscordChatExporter.Cli.dockerfile
@@ -18,7 +18,8 @@ RUN dotnet publish DiscordChatExporter.Cli \
 # Run
 FROM mcr.microsoft.com/dotnet/runtime-deps:7.0-alpine
 
-RUN mkdir -p /opt/discord_chat_exporter && \
+RUN apk add --no-cache tzdata && \
+    mkdir -p /opt/discord_chat_exporter && \
     adduser \
     --disabled-password \
     --no-create-home \

--- a/DiscordChatExporter.Cli.dockerfile
+++ b/DiscordChatExporter.Cli.dockerfile
@@ -1,5 +1,7 @@
 # Build
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build
+
+WORKDIR /build
 
 COPY favicon.ico ./
 COPY NuGet.config ./
@@ -7,16 +9,24 @@ COPY Directory.Build.props ./
 COPY DiscordChatExporter.Core ./DiscordChatExporter.Core
 COPY DiscordChatExporter.Cli ./DiscordChatExporter.Cli
 
-RUN dotnet publish DiscordChatExporter.Cli --configuration Release --output ./publish
+RUN dotnet publish DiscordChatExporter.Cli \
+    --self-contained \
+    --use-current-runtime \
+    --configuration Release \
+    --output ./publish
 
 # Run
-FROM mcr.microsoft.com/dotnet/runtime:7.0 AS run
+FROM mcr.microsoft.com/dotnet/runtime-deps:7.0-alpine
 
-RUN useradd dce
+RUN adduser \
+    --disabled-password \
+    --no-create-home \
+    dce
 USER dce
 
-COPY --from=build ./publish ./
+WORKDIR /opt/discord_chat_exporter
 
-WORKDIR ./out
+COPY --from=build /build/publish ./
 
-ENTRYPOINT ["dotnet", "../DiscordChatExporter.Cli.dll"]
+ENV PATH="$PATH:/opt/discord_chat_exporter"
+ENTRYPOINT ["DiscordChatExporter.Cli"]

--- a/DiscordChatExporter.Cli.dockerfile
+++ b/DiscordChatExporter.Cli.dockerfile
@@ -27,6 +27,9 @@ RUN apk add --no-cache tzdata && \
 USER dce
 COPY --from=build /build/publish /opt/discord_chat_exporter
 
+# Need to keep this as /out for backwards compatibility with documentation.
+# A lot of people have this directory mounted in their scripts files, so
+# changing it would break existing workflows.
 WORKDIR /out
 
 ENV PATH="$PATH:/opt/discord_chat_exporter"

--- a/DiscordChatExporter.Cli.dockerfile
+++ b/DiscordChatExporter.Cli.dockerfile
@@ -18,8 +18,8 @@ RUN dotnet publish DiscordChatExporter.Cli \
 # Run
 FROM mcr.microsoft.com/dotnet/runtime-deps:7.0-alpine
 
+# tzdata is needed for DateTimeOffset.ToLocalTime (for TimeZoneInfo.Local, to be precise)
 RUN apk add --no-cache tzdata && \
-    mkdir -p /opt/discord_chat_exporter && \
     adduser \
     --disabled-password \
     --no-create-home \

--- a/DiscordChatExporter.Core/Discord/Data/Common/FileSize.cs
+++ b/DiscordChatExporter.Core/Discord/Data/Common/FileSize.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 namespace DiscordChatExporter.Core.Discord.Data.Common;
 
@@ -39,7 +40,8 @@ public readonly partial record struct FileSize(long TotalBytes)
     }
 
     [ExcludeFromCodeCoverage]
-    public override string ToString() => $"{GetLargestWholeNumberValue():0.##} {GetLargestWholeNumberSymbol()}";
+    public override string ToString() =>
+        string.Create(CultureInfo.InvariantCulture, $"{GetLargestWholeNumberValue():0.##} {GetLargestWholeNumberSymbol()}");
 }
 
 public partial record struct FileSize


### PR DESCRIPTION
This reduces the image size from ~150 megabytes to ~80 megabytes, almost halving it. 

Also changed the order of `WORKDIR` and `COPY` directives in the resulting image to ensure that the build artifacts do not pollute (and do not conflict with existing files) the root directory. Added `WORKDIR` to the SDK image for the same reason.

Using relative paths in `WORKDIR` is actually against best practices - https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#workdir - so I got rid of them too.