### PR TITLE
Switch emoji CDN to jsDelivr

### DIFF
--- a/DiscordChatExporter.Core/Discord/Data/Emoji.cs
+++ b/DiscordChatExporter.Core/Discord/Data/Emoji.cs
@@ -45,7 +45,7 @@ public partial record Emoji
         : $"https://cdn.discordapp.com/emojis/{id}.png";
 
     private static string GetImageUrl(string name) =>
-        $"https://twemoji.maxcdn.com/v/latest/svg/{GetTwemojiId(name)}.svg";
+        $"https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/svg/{GetTwemojiId(name)}.svg";
 
     public static string GetImageUrl(Snowflake? id, string? name, bool isAnimated)
     {


### PR DESCRIPTION
As a result of MaxCDN being shut down, our twemoji links stopped working (see https://github.com/twitter/twemoji/issues/580). This makes all standard emoji fail to render, and exports which download assets are painfully slow due to the CDN timing out every time we attempt to reach it. This PR resolves the issue by instead using jsDelivr to retrieve twemoji images.