### PR TITLE
Limit the number of messages gathered

### DIFF
--- a/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
+++ b/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
@@ -13,6 +13,7 @@ using DiscordChatExporter.Core.Discord.Data;
 using DiscordChatExporter.Core.Exceptions;
 using DiscordChatExporter.Core.Exporting;
 using DiscordChatExporter.Core.Exporting.Filtering;
+using DiscordChatExporter.Core.Exporting.MessagesLimitation;
 using DiscordChatExporter.Core.Exporting.Partitioning;
 using DiscordChatExporter.Core.Utils;
 using Gress;
@@ -93,6 +94,12 @@ public abstract class ExportCommandBase : TokenCommandBase
     public string DateFormat { get; init; } = "dd-MMM-yy hh:mm tt";
 
     [CommandOption(
+        "limit",
+        Description = "Set a limit for messages gathered."
+    )]
+    public MessagesLimit MessagesLimit { get; init; } = MessagesLimit.Null;
+
+    [CommandOption(
         "fuck-russia",
         Description = "Don't print the Support Ukraine message to the console."
     )]
@@ -163,6 +170,7 @@ public abstract class ExportCommandBase : TokenCommandBase
                                     After,
                                     Before,
                                     PartitionLimit,
+                                    MessagesLimit,
                                     MessageFilter,
                                     ShouldDownloadAssets,
                                     ShouldReuseAssets,

--- a/DiscordChatExporter.Core/Exporting/ChannelExporter.cs
+++ b/DiscordChatExporter.Core/Exporting/ChannelExporter.cs
@@ -77,7 +77,8 @@ public class ChannelExporter
             // Export message
             await messageExporter.ExportMessageAsync(message, cancellationToken);
             exportedAnything = true;
-            count++;
+            if(message.Kind == MessageKind.Default || message.Kind == MessageKind.Reply)
+                count++;
         }
 
         // Throw if no messages were exported

--- a/DiscordChatExporter.Core/Exporting/ChannelExporter.cs
+++ b/DiscordChatExporter.Core/Exporting/ChannelExporter.cs
@@ -39,6 +39,7 @@ public class ChannelExporter
         await using var messageExporter = new MessageExporter(context);
 
         var exportedAnything = false;
+        var count = 0;
         var encounteredUsers = new HashSet<User>(IdBasedEqualityComparer.Instance);
 
         await foreach (var message in _discord.GetMessagesAsync(
@@ -49,6 +50,10 @@ public class ChannelExporter
                            cancellationToken))
         {
             cancellationToken.ThrowIfCancellationRequested();
+
+            // Stops if message count reached the limit set
+            if (request.MessagesLimit.IsReached(count))
+                break;
 
             // Skips any messages that fail to pass the supplied filter
             if (!request.MessageFilter.IsMatch(message))
@@ -72,6 +77,7 @@ public class ChannelExporter
             // Export message
             await messageExporter.ExportMessageAsync(message, cancellationToken);
             exportedAnything = true;
+            count++;
         }
 
         // Throw if no messages were exported

--- a/DiscordChatExporter.Core/Exporting/ExportRequest.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportRequest.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using DiscordChatExporter.Core.Discord;
 using DiscordChatExporter.Core.Discord.Data;
 using DiscordChatExporter.Core.Exporting.Filtering;
+using DiscordChatExporter.Core.Exporting.MessagesLimitation;
 using DiscordChatExporter.Core.Exporting.Partitioning;
 using DiscordChatExporter.Core.Utils;
 
@@ -18,6 +19,7 @@ public partial record ExportRequest(
     Snowflake? After,
     Snowflake? Before,
     PartitionLimit PartitionLimit,
+    MessagesLimit MessagesLimit,
     MessageFilter MessageFilter,
     bool ShouldDownloadAssets,
     bool ShouldReuseAssets,

--- a/DiscordChatExporter.Core/Exporting/MessagesLimitation/MessagesCountLimit.cs
+++ b/DiscordChatExporter.Core/Exporting/MessagesLimitation/MessagesCountLimit.cs
@@ -1,0 +1,11 @@
+﻿namespace DiscordChatExporter.Core.Exporting.MessagesLimitation;
+
+internal class MessagesCountLimit : MessagesLimit
+{
+    private readonly int _limit;
+
+    public MessagesCountLimit(int limit) => _limit = limit;
+
+    public override bool IsReached(int messagesCount) =>
+        messagesCount >= _limit;
+}

--- a/DiscordChatExporter.Core/Exporting/MessagesLimitation/MessagesLimit.cs
+++ b/DiscordChatExporter.Core/Exporting/MessagesLimitation/MessagesLimit.cs
@@ -1,0 +1,24 @@
+﻿using System.Globalization;
+using System;
+
+namespace DiscordChatExporter.Core.Exporting.MessagesLimitation;
+
+public abstract partial class MessagesLimit
+{
+    public abstract bool IsReached(int messagesCount);
+}
+
+public partial class MessagesLimit
+{
+    public static MessagesLimit Null { get; } = new NullMessagesLimit();
+
+    public static MessagesLimit? TryParse(string value, IFormatProvider? formatProvider = null)
+    {
+        if (int.TryParse(value, NumberStyles.Integer, formatProvider, out var messageCountLimit))
+            return new MessagesCountLimit(messageCountLimit);
+
+        return null;
+    }
+    public static MessagesLimit Parse(string value, IFormatProvider? formatProvider = null) =>
+       TryParse(value, formatProvider) ?? throw new FormatException($"Invalid messages limit '{value}'.");
+}

--- a/DiscordChatExporter.Core/Exporting/MessagesLimitation/NullMessagesLimit.cs
+++ b/DiscordChatExporter.Core/Exporting/MessagesLimitation/NullMessagesLimit.cs
@@ -1,0 +1,6 @@
+﻿namespace DiscordChatExporter.Core.Exporting.MessagesLimitation;
+
+internal class NullMessagesLimit : MessagesLimit
+{
+    public override bool IsReached(int messagesCount) => false;
+}

--- a/DiscordChatExporter.Gui/ViewModels/Components/DashboardViewModel.cs
+++ b/DiscordChatExporter.Gui/ViewModels/Components/DashboardViewModel.cs
@@ -16,6 +16,7 @@ using DiscordChatExporter.Gui.ViewModels.Framework;
 using Gress;
 using Gress.Completable;
 using Stylet;
+using DiscordChatExporter.Core.Exporting.MessagesLimitation;
 
 namespace DiscordChatExporter.Gui.ViewModels.Components;
 
@@ -185,6 +186,7 @@ public class DashboardViewModel : PropertyChangedBase
                             dialog.After?.Pipe(Snowflake.FromDate),
                             dialog.Before?.Pipe(Snowflake.FromDate),
                             dialog.PartitionLimit,
+                            MessagesLimit.Null,
                             dialog.MessageFilter,
                             dialog.ShouldDownloadAssets,
                             _settingsService.ShouldReuseAssets,


### PR DESCRIPTION
Objective: To limit the number of messages gathered in the system to improve performance and reduce the risk of data overload.

This pull request implements a messages limit feature that will limit the number of messages gathered to a specified number set in command line. This will improve system performance by reducing the amount of data being processed and stored, and also reduce the risk of data overload.

Example:
`--limit 50` would limit the file generated to 50 messages