### PR TITLE
Fix links of group icons

### DIFF
--- a/DiscordChatExporter.Core/Discord/Data/Channel.cs
+++ b/DiscordChatExporter.Core/Discord/Data/Channel.cs
@@ -43,7 +43,7 @@ public partial record Channel
             ? "gif"
             : "png";
 
-        return $"https://cdn.discordapp.com/icons/{id}/{iconHash}.{extension}";
+        return $"https://cdn.discordapp.com/channel-icons/{id}/{iconHash}.{extension}";
     }
 
     public static Channel Parse(JsonElement json, ChannelCategory? category = null, int? positionHint = null)


### PR DESCRIPTION
<!--

**Important:**

Please make sure that there is an existing issue that describes the problem solved by your pull request. If there isn't one, consider creating it first.
An open issue offers a good place to iron out requirements, discuss possible solutions, and ask questions.

Remember to also:

- Keep your pull request focused and as small as possible. If you want to contribute multiple unrelated changes, please create separate pull requests for each of them.
- Follow the coding style and conventions already established by the project. When in doubt about which style to use, ask in the comments to your pull request.
- If you want to start a discussion regarding a specific change you've made, add a review comment to your own code. This can be used to highlight something important or to seek further input from others.

-->

<!-- Please specify the issue addressed by this pull request -->
Closes #987 again, I guess.

Previously, group icons had the wrong link and therefore just showed a broken icon.

Sorry for the newline at the end of the file, I don't know how to tell GitHub to stop doing that.