### PR TITLE
Improve concurrency handling in `ExportAssetDownloader`

### DIFF
--- a/DiscordChatExporter.Cli.Tests/Infra/ExportWrapper.cs
+++ b/DiscordChatExporter.Cli.Tests/Infra/ExportWrapper.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
+using AsyncKeyedLock;
 using CliFx.Infrastructure;
 using DiscordChatExporter.Cli.Commands;
 using DiscordChatExporter.Cli.Tests.Utils;
@@ -20,7 +21,11 @@ namespace DiscordChatExporter.Cli.Tests.Infra;
 
 public static class ExportWrapper
 {
-    private static readonly ConcurrentDictionary<string, SemaphoreSlim> Locks = new();
+    private static readonly AsyncKeyedLocker<string> Locks = new(o =>
+    {
+        o.PoolSize = 20;
+        o.PoolInitialFill = 1;
+    });
 
     private static readonly string DirPath = Path.Combine(
         Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? Directory.GetCurrentDirectory(),
@@ -43,10 +48,7 @@ public static class ExportWrapper
     private static async ValueTask<string> ExportAsync(Snowflake channelId, ExportFormat format)
     {
         // Lock separately for each channel and format
-        var channelLock = Locks.GetOrAdd($"{channelId}_{format}", _ => new SemaphoreSlim(1, 1));
-        await channelLock.WaitAsync();
-
-        try
+        using (await Locks.LockAsync($"{channelId}_{format}").ConfigureAwait(false))
         {
             var fileName = channelId.ToString() + '.' + format.GetFileExtension();
             var filePath = Path.Combine(DirPath, fileName);
@@ -64,10 +66,6 @@ public static class ExportWrapper
             }
 
             return await File.ReadAllTextAsync(filePath);
-        }
-        finally
-        {
-            channelLock.Release();
         }
     }
 

--- a/DiscordChatExporter.Core/DiscordChatExporter.Core.csproj
+++ b/DiscordChatExporter.Core/DiscordChatExporter.Core.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AsyncKeyedLock" Version="6.1.1" />
     <PackageReference Include="Gress" Version="2.0.1" />
     <PackageReference Include="JsonExtensions" Version="1.2.0" />
     <PackageReference Include="Polly" Version="7.2.3" />

--- a/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
@@ -79,9 +79,9 @@ internal partial class ExportAssetDownloader
                     }
                 });
             }
-        }
 
-        return _pathCache[url] = filePath;
+            return _pathCache[url] = filePath;
+        }
     }
 }
 


### PR DESCRIPTION
Locking in ExportAssetDownloader to prevent concurrency issues and also prevent download of the same URL twice.