### PR TITLE
Preliminary support for threads

### DIFF
--- a/DiscordChatExporter.Cli/Commands/GetChannelsCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/GetChannelsCommand.cs
@@ -59,9 +59,12 @@ public class GetChannelsCommand : DiscordCommandBase
 
                 foreach (var thread in threads)
                 {
+                    // Indent
+                    await console.Output.WriteAsync('\t');
+
                     // Thread ID
                     await console.Output.WriteAsync(
-                        thread.Id.ToString().PadLeft(26, ' ').PadRight(18, ' ')
+                        thread.Id.ToString().PadRight(18, ' ')
                     );
 
                     // Separator

--- a/DiscordChatExporter.Cli/Commands/GetChannelsCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/GetChannelsCommand.cs
@@ -20,6 +20,12 @@ public class GetChannelsCommand : DiscordCommandBase
     )]
     public required Snowflake GuildId { get; init; }
 
+    [CommandOption(
+        "threads",
+        Description = "Display threads alongside channels."
+    )]
+    public bool ThreadShow { get; init; } = true;
+
     public override async ValueTask ExecuteAsync(IConsole console)
     {
         var cancellationToken = console.RegisterCancellationHandler();
@@ -45,24 +51,27 @@ public class GetChannelsCommand : DiscordCommandBase
             using (console.WithForegroundColor(ConsoleColor.White))
                 await console.Output.WriteLineAsync($"{channel.Category.Name} / {channel.Name}");
 
-            var threads = (await Discord.GetGuildChannelThreadsAsync(channel.Id.ToString(), cancellationToken))
+            if (ThreadShow)
+            {
+                var threads = (await Discord.GetGuildChannelThreadsAsync(channel.Id.ToString(), cancellationToken))
                 .OrderBy(c => c.Name)
                 .ToArray();
 
-            foreach (var thread in threads)
-            {
-                // Thread ID
-                await console.Output.WriteAsync(
-                    thread.Id.ToString().PadLeft(25, ' ').PadRight(18, ' ')
-                );
+                foreach (var thread in threads)
+                {
+                    // Thread ID
+                    await console.Output.WriteAsync(
+                        thread.Id.ToString().PadLeft(26, ' ').PadRight(18, ' ')
+                    );
 
-                // Separator
-                using (console.WithForegroundColor(ConsoleColor.DarkGray))
-                    await console.Output.WriteAsync(" | ");
+                    // Separator
+                    using (console.WithForegroundColor(ConsoleColor.DarkGray))
+                        await console.Output.WriteAsync(" | ");
 
-                // Channel name / thread name
-                using (console.WithForegroundColor(ConsoleColor.White))
-                    await console.Output.WriteLineAsync($"{channel.Name} / {thread.Name}");
+                    // Channel name / thread name
+                    using (console.WithForegroundColor(ConsoleColor.White))
+                        await console.Output.WriteLineAsync($"Thread / {thread.Name}");
+                }
             }
         }
     }

--- a/DiscordChatExporter.Cli/Commands/GetChannelsCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/GetChannelsCommand.cs
@@ -54,8 +54,8 @@ public class GetChannelsCommand : DiscordCommandBase
             if (ThreadShow)
             {
                 var threads = (await Discord.GetGuildChannelThreadsAsync(channel.Id.ToString(), cancellationToken))
-                .OrderBy(c => c.Name)
-                .ToArray();
+                    .OrderBy(c => c.Name)
+                    .ToArray();
 
                 foreach (var thread in threads)
                 {

--- a/DiscordChatExporter.Cli/Commands/GetChannelsCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/GetChannelsCommand.cs
@@ -24,7 +24,7 @@ public class GetChannelsCommand : DiscordCommandBase
         "include-threads",
         Description = "Display threads alongside channels."
     )]
-    public bool ThreadShow { get; init; } = true;
+    public bool IncludeTHreads { get; init; }
 
     public override async ValueTask ExecuteAsync(IConsole console)
     {
@@ -51,7 +51,7 @@ public class GetChannelsCommand : DiscordCommandBase
             using (console.WithForegroundColor(ConsoleColor.White))
                 await console.Output.WriteLineAsync($"{channel.Category.Name} / {channel.Name}");
 
-            if (ThreadShow)
+            if (IncludeThreads)
             {
                 var threads = (await Discord.GetGuildChannelThreadsAsync(channel.Id.ToString(), cancellationToken))
                     .OrderBy(c => c.Name)

--- a/DiscordChatExporter.Cli/Commands/GetChannelsCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/GetChannelsCommand.cs
@@ -21,7 +21,7 @@ public class GetChannelsCommand : DiscordCommandBase
     public required Snowflake GuildId { get; init; }
 
     [CommandOption(
-        "threads",
+        "include-threads",
         Description = "Display threads alongside channels."
     )]
     public bool ThreadShow { get; init; } = true;
@@ -68,7 +68,7 @@ public class GetChannelsCommand : DiscordCommandBase
                     using (console.WithForegroundColor(ConsoleColor.DarkGray))
                         await console.Output.WriteAsync(" | ");
 
-                    // Channel name / thread name
+                    // Thread / thread name
                     using (console.WithForegroundColor(ConsoleColor.White))
                         await console.Output.WriteLineAsync($"Thread / {thread.Name}");
                 }

--- a/DiscordChatExporter.Cli/Commands/GetChannelsCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/GetChannelsCommand.cs
@@ -44,6 +44,26 @@ public class GetChannelsCommand : DiscordCommandBase
             // Channel category / name
             using (console.WithForegroundColor(ConsoleColor.White))
                 await console.Output.WriteLineAsync($"{channel.Category.Name} / {channel.Name}");
+
+            var threads = (await Discord.GetGuildChannelThreadsAsync(channel.Id.ToString(), cancellationToken))
+                .OrderBy(c => c.Name)
+                .ToArray();
+
+            foreach (var thread in threads)
+            {
+                // Thread ID
+                await console.Output.WriteAsync(
+                    thread.Id.ToString().PadLeft(25, ' ').PadRight(18, ' ')
+                );
+
+                // Separator
+                using (console.WithForegroundColor(ConsoleColor.DarkGray))
+                    await console.Output.WriteAsync(" | ");
+
+                // Channel name / thread name
+                using (console.WithForegroundColor(ConsoleColor.White))
+                    await console.Output.WriteLineAsync($"{channel.Name} / {thread.Name}");
+            }
         }
     }
 }

--- a/DiscordChatExporter.Core/Discord/Data/Thread.cs
+++ b/DiscordChatExporter.Core/Discord/Data/Thread.cs
@@ -1,0 +1,50 @@
+﻿using System.Linq;
+using System.Text.Json;
+using DiscordChatExporter.Core.Discord.Data.Common;
+using DiscordChatExporter.Core.Utils.Extensions;
+using JsonExtensions.Reading;
+
+namespace DiscordChatExporter.Core.Discord.Data;
+
+// https://discord.com/developers/docs/resources/channel#channel-object-example-thread-channel
+public partial record Thread(
+    Snowflake Id,
+    ChannelKind Kind,
+    Snowflake GuildId,
+    string Name,
+    Snowflake? LastMessageId) : IHasId
+{
+
+}
+
+public partial record Thread
+{
+    public static Thread Parse(JsonElement json)
+    {
+        var id = json.GetProperty("id").GetNonWhiteSpaceString().Pipe(Snowflake.Parse);
+        var kind = (ChannelKind)json.GetProperty("type").GetInt32();
+
+        var guildId =
+            json.GetPropertyOrNull("guild_id")?.GetNonWhiteSpaceStringOrNull()?.Pipe(Snowflake.Parse) ?? default;
+
+        var name =
+            // Guild channel
+            json.GetPropertyOrNull("name")?.GetNonWhiteSpaceStringOrNull() ??
+
+            // Fallback
+            id.ToString();
+
+        var lastMessageId = json
+            .GetPropertyOrNull("last_message_id")?
+            .GetNonWhiteSpaceStringOrNull()?
+            .Pipe(Snowflake.Parse);
+
+        return new Thread(
+            id,
+            kind,
+            guildId,
+            name,
+            lastMessageId
+        );
+    }
+}

--- a/DiscordChatExporter.Core/Discord/Data/ThreadChannel.cs
+++ b/DiscordChatExporter.Core/Discord/Data/ThreadChannel.cs
@@ -7,7 +7,7 @@ using JsonExtensions.Reading;
 namespace DiscordChatExporter.Core.Discord.Data;
 
 // https://discord.com/developers/docs/resources/channel#channel-object-example-thread-channel
-public partial record Thread(
+public partial record ThreadChannel(
     Snowflake Id,
     ChannelKind Kind,
     Snowflake GuildId,
@@ -17,9 +17,9 @@ public partial record Thread(
 
 }
 
-public partial record Thread
+public partial record ThreadChannel
 {
-    public static Thread Parse(JsonElement json)
+    public static ThreadChannel Parse(JsonElement json)
     {
         var id = json.GetProperty("id").GetNonWhiteSpaceString().Pipe(Snowflake.Parse);
         var kind = (ChannelKind)json.GetProperty("type").GetInt32();
@@ -39,7 +39,7 @@ public partial record Thread
             .GetNonWhiteSpaceStringOrNull()?
             .Pipe(Snowflake.Parse);
 
-        return new Thread(
+        return new ThreadChannel(
             id,
             kind,
             guildId,

--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -215,14 +215,17 @@ public class DiscordClient
 
             var response = await TryGetJsonResponseAsync(url, cancellationToken);
 
-            foreach(var threadJson in response?.GetProperty("threads").EnumerateArray() ?? Enumerable.Empty<JsonElement>())
+            if (response is null)
+                break;
+
+            foreach (var threadJson in response.Value.GetProperty("threads").EnumerateArray())
                 yield return ThreadChannel.Parse(threadJson);
 
-            if (!(response?.GetProperty("has_more").GetBoolean() ?? false))
+            if (!response.Value.GetProperty("has_more").GetBoolean())
             {
                 break;
             }
-                currentOffset += response?.GetProperty("threads").GetArrayLength() ?? 0;
+                currentOffset += response.Value.GetProperty("threads").GetArrayLength();
         }
     }
 

--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -200,7 +200,7 @@ public class DiscordClient
         return Guild.Parse(response);
     }
 
-    public async IAsyncEnumerable<Data.Thread> GetGuildChannelThreadsAsync(
+    public async IAsyncEnumerable<ThreadChannel> GetGuildChannelThreadsAsync(
         string channelId,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
@@ -247,7 +247,7 @@ public class DiscordClient
 
         foreach (var threadJson in responseOrdered)
         {
-            var thread = Data.Thread.Parse(threadJson);
+            var thread = ThreadChannel.Parse(threadJson);
             yield return thread;
         }
     }

--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -222,7 +222,7 @@ public class DiscordClient
             {
                 break;
             }
-                currentOffset += 25;
+                currentOffset += response?.GetProperty("threads").GetArrayLength() ?? 0;
         }
     }
 


### PR DESCRIPTION
Since I have a fair bit of free time to spare, and since it seems that nobody else was going to do it, I've decided to work on a comprehensive threads/forums integration into DiscordChatExporter's GUI and CLI.

This first PR builds out the core of threads, and adds a proof of concept in the form of the CLI's `channels` command, which will now display a channel's threads below each channel. It is turned on by default, and can be turned off by using `--threads false`.

Full disclosure: I've actually never touched C# before this project. I'm primarily Python-oriented, but I've wanted this feature for a while, so I figured I'd dive in with this. This also means that I've likely implemented some things in a suboptimal or wrong manner, which I would appreciate feedback on before I proceed further. I'll give some specifics in a comment.

Closes #738.

