### PR TITLE
Use alternative endpoint to retrieve threads when requested by a bot

### DIFF
--- a/DiscordChatExporter.Cli/Commands/GetChannelsCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/GetChannelsCommand.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Threading;
-using System.Threading.Channels;
 using System.Threading.Tasks;
 using CliFx.Attributes;
 using CliFx.Infrastructure;

--- a/DiscordChatExporter.Cli/Commands/GetChannelsCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/GetChannelsCommand.cs
@@ -57,26 +57,23 @@ public class GetChannelsCommand : DiscordCommandBase
             using (console.WithForegroundColor(ConsoleColor.White))
                 await console.Output.WriteLineAsync($"{channel.Category.Name} / {channel.Name}");
 
-            foreach (var thread in threads)
+            foreach (var thread in threads.Where(t => t.ParentId == channel.Id))
             {
-                if (thread.ParentId == channel.Id)
-                {
-                    // Indent
-                    await console.Output.WriteAsync('\t');
+                // Indent
+                await console.Output.WriteAsync('\t');
 
-                    // Thread ID
-                    await console.Output.WriteAsync(
-                        thread.Id.ToString().PadRight(18, ' ')
-                    );
+                // Thread ID
+                await console.Output.WriteAsync(
+                    thread.Id.ToString().PadRight(18, ' ')
+                );
 
-                    // Separator
-                    using (console.WithForegroundColor(ConsoleColor.DarkGray))
-                        await console.Output.WriteAsync(" | ");
+                // Separator
+                using (console.WithForegroundColor(ConsoleColor.DarkGray))
+                    await console.Output.WriteAsync(" | ");
 
-                    // Thread name
-                    using (console.WithForegroundColor(ConsoleColor.White))
-                        await console.Output.WriteLineAsync($"Thread / {thread.Name}");
-                }
+                // Thread name
+                using (console.WithForegroundColor(ConsoleColor.White))
+                    await console.Output.WriteLineAsync($"Thread / {thread.Name}");
              }
         }
     }

--- a/DiscordChatExporter.Cli/Commands/GetChannelsCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/GetChannelsCommand.cs
@@ -36,14 +36,11 @@ public class GetChannelsCommand : DiscordCommandBase
             .ThenBy(c => c.Name)
             .ToArray();
 
-        var threads = Array.Empty<ChannelThread>();
-
-        if (IncludeThreads)
-        {
-            threads = (await Discord.GetGuildThreadsAsync(GuildId, cancellationToken))
+        var threads = IncludeThreads
+            ? (await Discord.GetGuildThreadsAsync(GuildId, cancellationToken))
                 .OrderBy(c => c.Name)
-                .ToArray();
-        }
+                .ToArray()
+            : Array.Empty<ChannelThread>();
 
         foreach (var channel in channels)
         {

--- a/DiscordChatExporter.Core/Discord/Data/ChannelThread.cs
+++ b/DiscordChatExporter.Core/Discord/Data/ChannelThread.cs
@@ -10,6 +10,7 @@ public record ChannelThread(
     Snowflake Id,
     ChannelKind Kind,
     Snowflake GuildId,
+    Snowflake ParentId,
     string Name,
     Snowflake? LastMessageId) : IHasId
 {
@@ -18,6 +19,7 @@ public record ChannelThread(
         var id = json.GetProperty("id").GetNonWhiteSpaceString().Pipe(Snowflake.Parse);
         var kind = (ChannelKind)json.GetProperty("type").GetInt32();
         var guildId = json.GetProperty("guild_id").GetNonWhiteSpaceString().Pipe(Snowflake.Parse);
+        var parentId = json.GetProperty("parent_id").GetNonWhiteSpaceString().Pipe(Snowflake.Parse);
         var name = json.GetProperty("name").GetNonWhiteSpaceString();
 
         var lastMessageId = json
@@ -29,6 +31,7 @@ public record ChannelThread(
             id,
             kind,
             guildId,
+            parentId,
             name,
             lastMessageId
         );

--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -353,6 +353,26 @@ public class DiscordClient
                         break;
                 }
             }
+            else
+            {
+                var responsePublic = await TryGetJsonResponseAsync($"channels/{channel.Id}/threads/archived/public", cancellationToken);
+                var responsePrivate = await TryGetJsonResponseAsync($"channels/{channel.Id}/threads/archived/private", cancellationToken);
+
+                if (responsePublic is not null)
+                {
+                    foreach (var threadJson in responsePublic.Value.GetProperty("threads").EnumerateArray())
+                    {
+                        yield return ChannelThread.Parse(threadJson);
+                    }
+                }
+                if (responsePrivate is not null)
+                {
+                    foreach (var threadJson in responsePrivate.Value.GetProperty("threads").EnumerateArray())
+                    {
+                        yield return ChannelThread.Parse(threadJson);
+                    }
+                }
+            }
         }
     }
 

--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -311,15 +311,18 @@ public class DiscordClient
         return Channel.Parse(response, category);
     }
 
-    public async IAsyncEnumerable<ChannelThread> GetChannelThreadsAsync(
-        Snowflake channelId,
+    public async IAsyncEnumerable<ChannelThread> GetGuildThreadsAsync(
+        Snowflake guildId,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        var channels = (await GetGuildChannelsAsync(guildId, cancellationToken))
+            .ToArray();
         var currentOffset = 0;
-        while (true)
+        var tokenKind = _resolvedTokenKind ??= await GetTokenKindAsync(cancellationToken);
+        foreach (var channel in channels)
         {
             var url = new UrlBuilder()
-                .SetPath($"channels/{channelId}/threads/search")
+                .SetPath($"channels/{channel.Id}/threads/search")
                 .SetQueryParameter("offset", currentOffset.ToString())
                 .Build();
 

--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -322,9 +322,12 @@ public class DiscordClient
         if (tokenKind == TokenKind.Bot)
         {
             var response = await TryGetJsonResponseAsync($"guilds/{guildId}/threads/active", cancellationToken);
-            foreach (var threadJson in response.Value.GetProperty("threads").EnumerateArray())
+            if (response is not null)
             {
-                yield return ChannelThread.Parse(threadJson);
+                foreach (var threadJson in response.Value.GetProperty("threads").EnumerateArray())
+                {
+                    yield return ChannelThread.Parse(threadJson);
+                }
             }
         }
         foreach (var channel in channels)

--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -321,13 +321,10 @@ public class DiscordClient
         
         if (tokenKind == TokenKind.Bot)
         {
-            var response = await TryGetJsonResponseAsync($"guilds/{guildId}/threads/active", cancellationToken);
-            if (response is not null)
+            var response = await GetJsonResponseAsync($"guilds/{guildId}/threads/active", cancellationToken);
+            foreach (var threadJson in response.GetProperty("threads").EnumerateArray())
             {
-                foreach (var threadJson in response.Value.GetProperty("threads").EnumerateArray())
-                {
-                    yield return ChannelThread.Parse(threadJson);
-                }
+                yield return ChannelThread.Parse(threadJson);
             }
         }
         foreach (var channel in channels)


### PR DESCRIPTION
This PR refactors the recently added `GetChannelThreadsAsync` (now named `GetGuildThreadsAsync`) to return all threads in a single guild instead of all threads in a single channel. This means that the nonsensical API endpoints Discord created for bots will work in the same way as the single user endpoint already in place.

This PR does not address any specific Github issue, but was instead brought up as an issue in the Discord by @CanePlayz and @Tyrrrz.