### PR TITLE
Export role details in JSON format

### DIFF
--- a/DiscordChatExporter.Core/Exporting/ExportContext.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportContext.cs
@@ -106,6 +106,18 @@ internal class ExportContext
             .FirstOrDefault();
     }
 
+    public IEnumerable<Role> TryGetUserRoles(Snowflake id)
+    {
+        var member = TryGetMember(id);
+
+        return member?
+            .RoleIds
+            .Select(TryGetRole)
+            .WhereNotNull()
+            .OrderByDescending(r => r.Position)
+            .ToArray() ?? Array.Empty<Role>();
+    }
+
     public async ValueTask<string> ResolveAssetUrlAsync(string url, CancellationToken cancellationToken = default)
     {
         if (!Request.ShouldDownloadAssets)

--- a/DiscordChatExporter.Core/Exporting/JsonMessageWriter.cs
+++ b/DiscordChatExporter.Core/Exporting/JsonMessageWriter.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Threading;
@@ -48,6 +49,9 @@ internal class JsonMessageWriter : MessageWriter
         _writer.WriteString("color", Context.TryGetUserColor(user.Id)?.ToHex());
         _writer.WriteBoolean("isBot", user.IsBot);
 
+        _writer.WritePropertyName("roles");
+        await WriteRolesAsync(Context.TryGetUserRoles(user.Id), cancellationToken);
+
         _writer.WriteString(
             "avatarUrl",
             await Context.ResolveAssetUrlAsync(
@@ -57,6 +61,28 @@ internal class JsonMessageWriter : MessageWriter
         );
 
         _writer.WriteEndObject();
+        await _writer.FlushAsync(cancellationToken);
+    }
+
+    private async ValueTask WriteRolesAsync(
+        IEnumerable<Role> roles,
+        CancellationToken cancellationToken = default)
+    {
+        _writer.WriteStartArray();
+
+        foreach (var role in roles)
+        {
+            _writer.WriteStartObject();
+
+            _writer.WriteString("id", role.Id.ToString());
+            _writer.WriteString("name", role.Name);
+            _writer.WriteString("color", role.Color?.ToHex());
+            _writer.WriteNumber("position", role.Position);
+
+            _writer.WriteEndObject();
+        }
+
+        _writer.WriteEndArray();
         await _writer.FlushAsync(cancellationToken);
     }
 


### PR DESCRIPTION
<!--

**Important:**

Please make sure that there is an existing issue that describes the problem solved by your pull request. If there isn't one, consider creating it first.
An open issue offers a good place to iron out requirements, discuss possible solutions, and ask questions.

Remember to also:

- Keep your pull request focused and as small as possible. If you want to contribute multiple unrelated changes, please create separate pull requests for each of them.
- Follow the coding style and conventions already established by the project. When in doubt about which style to use, ask in the comments to your pull request.
- If you want to start a discussion regarding a specific change you've made, add a review comment to your own code. This can be used to highlight something important or to seek further input from others.

-->

<!-- Please specify the issue addressed by this pull request -->


This pull request adds `roles` field to `messages.author` in JSON output format.

If no roles are available, empty array is created:
```json
"author": {
	...
	"roles": [],
	...
},
```
If role color is not available, `null` value is used. Else the color is is converted to hexcode

```json
"roles": [
	{
		"id": "712543702037017113",
		"name": "mod",
		"color": null,
		"position": 239
	},
	{
		"id": "766532373335259678",
		"name": "Orange",
		"color": "#F58231",
		"position": 218
	},
	...
]
```

Roles are sorted by position, as they are in the Discord client

Tested CLI export in Json format - DM channel (no roles) and Guild channel (with roles). \
GUI not tested, but the changes should not affect it.



