### PR TITLE
Add export timestamp in JSON format

### DIFF
--- a/DiscordChatExporter.Core/Exporting/JsonMessageWriter.cs
+++ b/DiscordChatExporter.Core/Exporting/JsonMessageWriter.cs
@@ -236,6 +236,9 @@ internal class JsonMessageWriter : MessageWriter
         _writer.WriteString("before", Context.Request.Before?.ToDate());
         _writer.WriteEndObject();
 
+        // Timestamp
+        _writer.WriteString("timestamp", System.DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.ffzzz"));
+
         // Message array (start)
         _writer.WriteStartArray("messages");
         await _writer.FlushAsync(cancellationToken);

--- a/DiscordChatExporter.Core/Exporting/JsonMessageWriter.cs
+++ b/DiscordChatExporter.Core/Exporting/JsonMessageWriter.cs
@@ -237,7 +237,7 @@ internal class JsonMessageWriter : MessageWriter
         _writer.WriteEndObject();
 
         // Timestamp
-        _writer.WriteString("timestamp", System.DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.ffzzz"));
+        _writer.WriteString("exportedAt", System.DateTimeOffset.UtcNow);
 
         // Message array (start)
         _writer.WriteStartArray("messages");


### PR DESCRIPTION
This pull request adds a timestamp of time+date, when the JSON export was created. The format `yyyy-MM-ddTHH:mm:ss.ffzzz` is the same as seen with the other timestamps `timestamp`, `timestampEdited`,`callEndedTimestamp`,...

This is useful to know when the export was created to compare multiple exports of the same channel (for example profile pictures, nicknames change without modifying `timestampEdited` field in message object). And the feature has zero future maintenance cost.

Example - timestamp is added as `timestamp` field in the root object:
```json
{
  ...
  "dateRange": {
    "after": null,
    "before": null
  },
  "timestamp": "2023-07-06T17:02:25.02+00:00",
  "messages": [
    {
  ...
}
```

Tested CLI export in Json format - Guild channel.
GUI not tested, but the changes should not affect it.

