### PR TITLE
Optimize fetching threads

### DIFF
--- a/DiscordChatExporter.Cli/Commands/ExportAllCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/ExportAllCommand.cs
@@ -66,22 +66,6 @@ public class ExportAllCommand : ExportCommandBase
                     if (!IncludeVoiceChannels && channel.Kind.IsVoice())
                         continue;
 
-                    // if --after is specified, skip channels with no new messages
-                    if (
-                        After != null
-                        && channel.LastMessageId != null
-                        && After > channel.LastMessageId
-                    )
-                        continue;
-
-                    // if --before is specified, skip channels created after the specified date
-                    if (Before != null && Before < channel.Id)
-                        continue;
-
-                    // skip forums, they are exported as threads
-                    if (channel.Kind == ChannelKind.GuildForum)
-                        continue;
-
                     channels.Add(channel);
                 }
 

--- a/DiscordChatExporter.Cli/Commands/ExportAllCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/ExportAllCommand.cs
@@ -66,6 +66,22 @@ public class ExportAllCommand : ExportCommandBase
                     if (!IncludeVoiceChannels && channel.Kind.IsVoice())
                         continue;
 
+                    // if --after is specified, skip channels with no new messages
+                    if (
+                        After != null
+                        && channel.LastMessageId != null
+                        && After > channel.LastMessageId
+                    )
+                        continue;
+
+                    // if --before is specified, skip channels created after the specified date
+                    if (Before != null && Before < channel.Id)
+                        continue;
+
+                    // skip forums, they are exported as threads
+                    if (channel.Kind == ChannelKind.GuildForum)
+                        continue;
+
                     channels.Add(channel);
                 }
 
@@ -76,6 +92,8 @@ public class ExportAllCommand : ExportCommandBase
                         var thread in Discord.GetGuildThreadsAsync(
                             guild.Id,
                             ThreadInclusionMode == ThreadInclusionMode.All,
+                            Before,
+                            After,
                             cancellationToken
                         )
                     )

--- a/DiscordChatExporter.Cli/Commands/ExportGuildCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/ExportGuildCommand.cs
@@ -44,8 +44,21 @@ public class ExportGuildCommand : ExportCommandBase
             if (!IncludeVoiceChannels && channel.Kind.IsVoice())
                 continue;
 
+            // if --after is specified, skip channels with no new messages
+            if (After != null && channel.LastMessageId != null && After > channel.LastMessageId)
+                continue;
+
+            // if --before is specified, skip channels created after the specified date
+            if (Before != null && Before < channel.Id)
+                continue;
+
+            // skip forums, they are exported as threads
+            if (channel.Kind == ChannelKind.GuildForum)
+                continue;
+
             channels.Add(channel);
         }
+        // return;
 
         // Threads
         if (ThreadInclusionMode != ThreadInclusionMode.None)
@@ -54,6 +67,8 @@ public class ExportGuildCommand : ExportCommandBase
                 var thread in Discord.GetGuildThreadsAsync(
                     GuildId,
                     ThreadInclusionMode == ThreadInclusionMode.All,
+                    Before,
+                    After,
                     cancellationToken
                 )
             )

--- a/DiscordChatExporter.Cli/Commands/ExportGuildCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/ExportGuildCommand.cs
@@ -46,7 +46,6 @@ public class ExportGuildCommand : ExportCommandBase
 
             channels.Add(channel);
         }
-        // return;
 
         // Threads
         if (ThreadInclusionMode != ThreadInclusionMode.None)

--- a/DiscordChatExporter.Cli/Commands/ExportGuildCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/ExportGuildCommand.cs
@@ -44,18 +44,6 @@ public class ExportGuildCommand : ExportCommandBase
             if (!IncludeVoiceChannels && channel.Kind.IsVoice())
                 continue;
 
-            // if --after is specified, skip channels with no new messages
-            if (After != null && channel.LastMessageId != null && After > channel.LastMessageId)
-                continue;
-
-            // if --before is specified, skip channels created after the specified date
-            if (Before != null && Before < channel.Id)
-                continue;
-
-            // skip forums, they are exported as threads
-            if (channel.Kind == ChannelKind.GuildForum)
-                continue;
-
             channels.Add(channel);
         }
         // return;

--- a/DiscordChatExporter.Cli/Commands/GetChannelsCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/GetChannelsCommand.cs
@@ -52,6 +52,8 @@ public class GetChannelsCommand : DiscordCommandBase
                     await Discord.GetGuildThreadsAsync(
                         GuildId,
                         ThreadInclusionMode == ThreadInclusionMode.All,
+                        null,
+                        null,
                         cancellationToken
                     )
                 )

--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -329,7 +329,7 @@ public class DiscordClient
                         var thread = Channel.Parse(threadJson, channel);
 
                         // if --after is specified, we can break early, because the threads are sorted by last message time
-                        if (after != null && after > thread.LastMessageId)
+                        if (after is not null && after > thread.LastMessageId)
                         {
                             containsOlder = true;
                             break;

--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -378,7 +378,7 @@ public class DiscordClient
                             var thread = Channel.Parse(threadJson, channel);
 
                             // if --after is specified, we can break early, because the threads are sorted by last message time
-                            if (after != null && after > thread.LastMessageId)
+                            if (after is not null && after > thread.LastMessageId)
                             {
                                 containsOlder = true;
                                 break;

--- a/DiscordChatExporter.Core/Exporting/ChannelExporter.cs
+++ b/DiscordChatExporter.Core/Exporting/ChannelExporter.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using DiscordChatExporter.Core.Discord;
+using DiscordChatExporter.Core.Discord.Data;
 using DiscordChatExporter.Core.Exceptions;
 using Gress;
 
@@ -31,6 +32,20 @@ public class ChannelExporter
             throw new DiscordChatExporterException(
                 "Channel does not contain any messages within the specified period."
             );
+        }
+
+        // Check if the 'before' boundary is valid
+        if (request.Before is not null && request.Channel.Id > request.Before)
+        {
+            throw new DiscordChatExporterException(
+                "Channel does not contain any messages within the specified period."
+            );
+        }
+
+        // Skip forum channels, they are exported as threads
+        if (request.Channel.Kind == ChannelKind.GuildForum)
+        {
+            throw new DiscordChatExporterException("Channel is a forum.");
         }
 
         // Build context


### PR DESCRIPTION
By adding new threads support, `Fetching channels...` stage takes too long for bigger guilds with many threads. Some data doesn't need to be fetched, because we know, that those channels/threads won't be exported.

If `--after` parameter is specified, the main speed-up is to break early of thread fetching, by sorting threads by `LastMessageId` (endpoint `channels/{channel.Id}/threads/search` - query parameters `sort_by=last_message_time&sort_order=desc`) and comparing `After` and `LastMessageId`. This check is implemented only for user tokens

Skip thread export for channel if:
- `channel.Kind == ChannelKind.GuildCategory` - categories never have threads
- `channel.Kind.IsVoice()` - voice channels never have threads
- `channel.LastMessageId` - if the channel is empty, the channel doesn't have threads (if the channel is forum post, `LastMessageId` will be `channel.Id` of the last forum post)
- (`--before`) `Before < channel.Id` - if the channel is created in the future 

Skip export of these ordinary channels if:
- `After > channel.LastMessageId` - the channel doesn't have new messages (BUT it can have new messages in threads, that's why we don't skip it in thread exports)

---

Potential problems:
- channels skipped this way won't be printed in section `Failed to export XXX channel(s):`
- Old bug - timestamp supplied using `--before` can overflow into the future - for example `--before "2010-08-30T00:00:00.000Z"` overflows to snowflake `16548918821562351616` (`2140-01-12T07:35:11.104Z`). By adding more early checks, there may be more cases, where this bug can be an issue

Tested - CLI json export using `exportGuild` with `--include-threads All` and combinations of `--before` and `--after` parameters