### PR TITLE
Remove CDN signature before hashing asset URL

### DIFF
--- a/DiscordChatExporter.Cli/Commands/ExportAllCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/ExportAllCommand.cs
@@ -55,7 +55,9 @@ public class ExportAllCommand : ExportCommandBase
         {
             await foreach (var guild in Discord.GetUserGuildsAsync(cancellationToken))
             {
-                await console.Output.WriteLineAsync($"Fetching channels for guild '{guild.Name}'...");
+                await console.Output.WriteLineAsync(
+                    $"Fetching channels for guild '{guild.Name}'..."
+                );
 
                 // Regular channels
                 await foreach (

--- a/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web;
 using AsyncKeyedLock;
 using DiscordChatExporter.Core.Utils;
 using DiscordChatExporter.Core.Utils.Extensions;
@@ -101,12 +102,24 @@ internal partial class ExportAssetDownloader
 
 internal partial class ExportAssetDownloader
 {
-    private static string GetUrlHash(string url) =>
-        SHA256
+    private static string GetUrlHash(string url)
+    {
+        // Strip out ex, is and hm query params to create a consistent hash
+        var uriBuilder = new UriBuilder(url);
+        var query = HttpUtility.ParseQueryString(uriBuilder.Query);
+        query.Remove("ex");
+        query.Remove("is");
+        query.Remove("hm");
+        uriBuilder.Query = query.ToString();
+        url = uriBuilder.ToString();
+        url = url.Replace(":443", "");
+
+        return SHA256
             .HashData(Encoding.UTF8.GetBytes(url))
             .ToHex()
             // 5 chars ought to be enough for anybody
             .Truncate(5);
+    }
 
     private static string GetFileNameFromUrl(string url)
     {

--- a/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
@@ -104,15 +104,23 @@ internal partial class ExportAssetDownloader
 {
     private static string GetUrlHash(string url)
     {
-        // Strip out ex, is and hm query params to create a consistent hash
-        var uriBuilder = new UriBuilder(url);
-        var query = HttpUtility.ParseQueryString(uriBuilder.Query);
-        query.Remove("ex");
-        query.Remove("is");
-        query.Remove("hm");
-        uriBuilder.Query = query.ToString();
-        url = uriBuilder.ToString();
-        url = url.Replace(":443", "");
+        // Strip out ex, is and hm query params from Discord CDN URLs to create a consistent hash
+        if (
+            url.Contains("cdn.discordapp.com")
+            && url.Contains("ex")
+            && url.Contains("is")
+            && url.Contains("hm")
+        )
+        {
+            var uriBuilder = new UriBuilder(url);
+            var query = HttpUtility.ParseQueryString(uriBuilder.Query);
+            query.Remove("ex");
+            query.Remove("is");
+            query.Remove("hm");
+            uriBuilder.Query = query.ToString();
+            url = uriBuilder.ToString();
+            url = url.Replace(":443", "");
+        }
 
         return SHA256
             .HashData(Encoding.UTF8.GetBytes(url))


### PR DESCRIPTION
Discord recently introduced signed cdn links. This change breaks `--reuse-media` for assets, because url is used to detect if the file is already downloaded.

This pull request solves this issue by stripping out `ex`, `is` and `hm` query params before hashing the url.