### PR TITLE
Add command to fix broken permissions to Linux installation instructions

### DIFF
--- a/.docs/Linux.md
+++ b/.docs/Linux.md
@@ -14,7 +14,10 @@ Please follow the [instructions provided here](https://github.com/Tyrrrz/Discord
 ```console
 dotnet DiscordChatExporter.Cli.dll export -t TOKEN -c CHANNEL
 ```
-
+If the above command throws a "Permission denied" error, execute this command to fix the permissions:
+```console
+chmod 644 *.dll DiscordChatExporter.*
+```
 > [How to get Token and Channel IDs](https://github.com/Tyrrrz/DiscordChatExporter/blob/master/.docs/Token-and-IDs.md).
 
 There's much more you can do with DCE.CLI! Read the [CLI explained](https://github.com/Tyrrrz/DiscordChatExporter/blob/master/.docs/Getting-started.md#dcecli-commands-) page to get started.

--- a/.docs/Linux.md
+++ b/.docs/Linux.md
@@ -14,10 +14,11 @@ Please follow the [instructions provided here](https://github.com/Tyrrrz/Discord
 ```console
 dotnet DiscordChatExporter.Cli.dll export -t TOKEN -c CHANNEL
 ```
+
 If the above command throws a "Permission denied" error, execute this command to fix the permissions:
+
 ```console
 chmod 644 *.dll DiscordChatExporter.*
-```
 > [How to get Token and Channel IDs](https://github.com/Tyrrrz/DiscordChatExporter/blob/master/.docs/Token-and-IDs.md).
 
 There's much more you can do with DCE.CLI! Read the [CLI explained](https://github.com/Tyrrrz/DiscordChatExporter/blob/master/.docs/Getting-started.md#dcecli-commands-) page to get started.


### PR DESCRIPTION
The CLI zip generated by the build workflow doesn't have any file permissions set, which can cause an error when trying to run DiscordChatExporter depending on how you extract the zip. It doesn't appear to affect MacOS or Windows, only Linux.
```
Cannot use file stream for [/.../DiscordChatExporter.Cli.runtimeconfig.json]: Permission denied
Invalid runtimeconfig.json [/.../DiscordChatExporter.Cli.runtimeconfig.json] [/.../DiscordChatExporter.Cli.runtimeconfig.dev.json]
```
This is [a limitation](https://github.com/actions/upload-artifact#maintaining-file-permissions-and-case-sensitive-files) with upload-artifact.

This PR adds a command to the Linux installation docs to set the permissions to 644 (the default file permissions).