### PR TITLE
Skip CI workflow when token is unset

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Run tests
         # Tests need access to secrets, so we can't run them against PRs because of limited trust
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ github.event_name != 'pull_request' && env.DISCORD_TOKEN != '' }}
         env:
           DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
         run: >

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ obj/
 
 # Test results
 TestResults/
+*.userprefs


### PR DESCRIPTION
Forking this repository leads to the CI workflows failing on the fork, since forks won't have access to the necessary token. This fixes that by simply skipping the failing workflow in such cases. Also, a minor gitignore update slipped in while I was at it, too.
