### PR TITLE
Fix GUI link in docs going to CLI page

### DIFF
--- a/.docs/Readme.md
+++ b/.docs/Readme.md
@@ -5,7 +5,7 @@
 - [Get .NET Core Runtime](Dotnet.md) (Required for CLI; Installed automatically for GUI; Not required in Docker)
 - [Windows](Getting-started.md#gui-or-cli) | [macOS](MacOS.md) | [Linux](Linux.md) | [Docker](Docker.md)
 - Getting started:
-  - [Using the GUI](Using-the-CLI.md)
+  - [Using the GUI](Using-the-GUI.md)
   - [Using the CLI](Using-the-CLI.md)
   - [File formats](Getting-started.md#file-formats)
 


### PR DESCRIPTION
The "Using the GUI" link in the main docs page goes to the "Using the CLI" page, this PR fixes that.