### PR TITLE
Refer to "guilds" as "servers" in docs and UI elements

### DIFF
--- a/.docs/Using-the-CLI.md
+++ b/.docs/Using-the-CLI.md
@@ -38,16 +38,16 @@ dotnet DiscordChatExporter.Cli.dll
 
 ## CLI commands
 
-| Command                 | Description                                         |
-|-------------------------|-----------------------------------------------------|
-| export                  | Exports a channel                                   |
-| exportdm                | Exports all direct message channels                 |
-| exportguild             | Exports all channels within the specified server    |
-| exportall               | Exports all accessible channels                     |
-| channels                | Outputs the list of channels in the given server    |
-| dm                      | Outputs the list of direct message channels         |
-| guilds                  | Outputs the list of accessible servers              |
-| guide                   | Explains how to obtain token, guild, and channel ID |
+| Command                 | Description                                          |
+|-------------------------|------------------------------------------------------|
+| export                  | Exports a channel                                    |
+| exportdm                | Exports all direct message channels                  |
+| exportguild             | Exports all channels within the specified server     |
+| exportall               | Exports all accessible channels                      |
+| channels                | Outputs the list of channels in the given server     |
+| dm                      | Outputs the list of direct message channels          |
+| guilds                  | Outputs the list of accessible servers               |
+| guide                   | Explains how to obtain token, server, and channel ID |
 
 To use the commands, you'll need a token. For the instructions on how to get a token, please refer to [this page](Token-and-IDs.md), or run `dotnet DiscordChatExporter.Cli.dll guide`.
 
@@ -110,7 +110,7 @@ dotnet DiscordChatExporter.Cli.dll export -t "mfa.Ifrn" -c 53555 -o "C:\Discord 
 
 #### Generating the filename and output directory dynamically
 
-You can use template tokens to generate the output file path based on the guild and channel metadata.
+You can use template tokens to generate the output file path based on the server and channel metadata.
 
 ```console
 dotnet DiscordChatExporter.Cli.dll export -t "mfa.Ifrn" -c 53555 -o "C:\Discord Exports\%G\%T\%C.html"
@@ -122,8 +122,8 @@ path: `C:\Discord Exports\My server\Text channels\my-channel.html`
 
 Here is the full list of supported template tokens:
 
-- `%g` - guild ID
-- `%G` - guild name
+- `%g` - server ID
+- `%G` - server name
 - `%t` - category ID
 - `%T` - category name
 - `%c` - channel ID
@@ -217,9 +217,9 @@ Don't forget to quote (") the date if it has spaces!
 More info about .NET date
 formats [here](https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings).
 
-### Export channels from a specific guild (server)
+### Export channels from a specific server
 
-To export all channels in a specific guild, use the `exportguild` command and provide the guild ID through the `-g|--guild` option:
+To export all channels in a specific server, use the `exportguild` command and provide the server ID through the `-g|--guild` option:
 
 ```console
 dotnet DiscordChatExporter.Cli.dll exportguild -t "mfa.Ifrn" -g 21814
@@ -261,9 +261,9 @@ To exclude DMs, add the `--include-dm false` option.
 dotnet DiscordChatExporter.Cli.dll exportall -t "mfa.Ifrn" --include-dm false
 ```
 
-### List channels in a guild (server)
+### List channels in a server
 
-To list the channels available in a specific guild, use the `channels` command and provide the guild ID through the `-g|--guild` option:
+To list the channels available in a specific server, use the `channels` command and provide the server ID through the `-g|--guild` option:
 
 ```console
 dotnet DiscordChatExporter.Cli.dll channels -t "mfa.Ifrn" -g 21814
@@ -277,9 +277,9 @@ To list all DM channels accessible to the current account, use the `dm` command:
 dotnet DiscordChatExporter.Cli.dll dm -t "mfa.Ifrn"
 ```
 
-### List guilds (servers)
+### List servers
 
-To list all guilds accessible by the current account, use the `guilds` command:
+To list all servers accessible by the current account, use the `guilds` command:
 
 ```console
 dotnet DiscordChatExporter.Cli.dll guilds -t "mfa.Ifrn" > C:\path\to\output.txt

--- a/DiscordChatExporter.Cli/Commands/ExportAllCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/ExportAllCommand.cs
@@ -21,7 +21,7 @@ public class ExportAllCommand : ExportCommandBase
     [CommandOption("include-dm", Description = "Include direct message channels.")]
     public bool IncludeDirectChannels { get; init; } = true;
 
-    [CommandOption("include-guilds", Description = "Include guild channels.")]
+    [CommandOption("include-guilds", Description = "Include server channels.")]
     public bool IncludeGuildChannels { get; init; } = true;
 
     [CommandOption("include-vc", Description = "Include voice channels.")]
@@ -56,7 +56,7 @@ public class ExportAllCommand : ExportCommandBase
                 // Regular channels
                 await console
                     .Output
-                    .WriteLineAsync($"Fetching channels for guild '{guild.Name}'...");
+                    .WriteLineAsync($"Fetching channels for server '{guild.Name}'...");
 
                 var fetchedChannelsCount = 0;
                 await console
@@ -96,7 +96,7 @@ public class ExportAllCommand : ExportCommandBase
                 {
                     await console
                         .Output
-                        .WriteLineAsync($"Fetching threads for guild '{guild.Name}'...");
+                        .WriteLineAsync($"Fetching threads for server '{guild.Name}'...");
 
                     var fetchedThreadsCount = 0;
                     await console

--- a/DiscordChatExporter.Cli/Commands/ExportGuildCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/ExportGuildCommand.cs
@@ -12,10 +12,10 @@ using Spectre.Console;
 
 namespace DiscordChatExporter.Cli.Commands;
 
-[Command("exportguild", Description = "Exports all channels within the specified guild.")]
+[Command("exportguild", Description = "Exports all channels within the specified server.")]
 public class ExportGuildCommand : ExportCommandBase
 {
-    [CommandOption("guild", 'g', Description = "Guild ID.")]
+    [CommandOption("guild", 'g', Description = "Server ID.")]
     public required Snowflake GuildId { get; init; }
 
     [CommandOption("include-vc", Description = "Include voice channels.")]

--- a/DiscordChatExporter.Cli/Commands/GetChannelsCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/GetChannelsCommand.cs
@@ -12,10 +12,10 @@ using DiscordChatExporter.Core.Utils.Extensions;
 
 namespace DiscordChatExporter.Cli.Commands;
 
-[Command("channels", Description = "Get the list of channels in a guild.")]
+[Command("channels", Description = "Get the list of channels in a server.")]
 public class GetChannelsCommand : DiscordCommandBase
 {
-    [CommandOption("guild", 'g', Description = "Guild ID.")]
+    [CommandOption("guild", 'g', Description = "Server ID.")]
     public required Snowflake GuildId { get; init; }
 
     [CommandOption("include-vc", Description = "Include voice channels.")]

--- a/DiscordChatExporter.Cli/Commands/GetGuildsCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/GetGuildsCommand.cs
@@ -9,7 +9,7 @@ using DiscordChatExporter.Core.Utils.Extensions;
 
 namespace DiscordChatExporter.Cli.Commands;
 
-[Command("guilds", Description = "Gets the list of accessible guilds.")]
+[Command("guilds", Description = "Gets the list of accessible servers.")]
 public class GetGuildsCommand : DiscordCommandBase
 {
     public override async ValueTask ExecuteAsync(IConsole console)

--- a/DiscordChatExporter.Cli/Commands/GuideCommand.cs
+++ b/DiscordChatExporter.Cli/Commands/GuideCommand.cs
@@ -6,7 +6,7 @@ using CliFx.Infrastructure;
 
 namespace DiscordChatExporter.Cli.Commands;
 
-[Command("guide", Description = "Explains how to obtain the token, guild or channel ID.")]
+[Command("guide", Description = "Explains how to obtain the token, server or channel ID.")]
 public class GuideCommand : ICommand
 {
     public ValueTask ExecuteAsync(IConsole console)
@@ -49,7 +49,7 @@ public class GuideCommand : ICommand
 
         // Guild or channel ID
         using (console.WithForegroundColor(ConsoleColor.White))
-            console.Output.WriteLine("To get the ID of a guild or a channel:");
+            console.Output.WriteLine("To get the ID of a server or a channel:");
 
         console.Output.WriteLine(" 1. Open Discord");
         console.Output.WriteLine(" 2. Open Settings");
@@ -58,7 +58,7 @@ public class GuideCommand : ICommand
         console
             .Output
             .WriteLine(
-                " 5. Right-click on the desired guild or channel and click Copy Server ID or Copy Channel ID"
+                " 5. Right-click on the desired server or channel and click Copy Server ID or Copy Channel ID"
             );
         console.Output.WriteLine();
 

--- a/DiscordChatExporter.Gui/Views/Dialogs/ExportSetupView.xaml
+++ b/DiscordChatExporter.Gui/Views/Dialogs/ExportSetupView.xaml
@@ -97,10 +97,10 @@
                                     <Run Text="Available template tokens:" />
                                     <LineBreak />
                                     <Run FontWeight="SemiBold" Text="%g" />
-                                    <Run Text="— guild ID" />
+                                    <Run Text="— server ID" />
                                     <LineBreak />
                                     <Run FontWeight="SemiBold" Text="%G" />
-                                    <Run Text="— guild name" />
+                                    <Run Text="— server name" />
                                     <LineBreak />
                                     <Run FontWeight="SemiBold" Text="%t" />
                                     <Run Text="— category ID" />


### PR DESCRIPTION
"Guilds" is the internal name for "servers" in Discord, however publicly they're still referred to as "servers". This change should make the docs and some UI elements appear less confusing to users who are not familiar with this trivia. CLI options will remain unchanged for backwards compatibility.