### PR TITLE
Warn about redirected streams in the CLI only when running inside Docker

### DIFF
--- a/DiscordChatExporter.Cli/Commands/Base/DiscordCommandBase.cs
+++ b/DiscordChatExporter.Cli/Commands/Base/DiscordCommandBase.cs
@@ -4,6 +4,7 @@ using CliFx;
 using CliFx.Attributes;
 using CliFx.Infrastructure;
 using DiscordChatExporter.Core.Discord;
+using DiscordChatExporter.Core.Utils;
 
 namespace DiscordChatExporter.Cli.Commands.Base;
 
@@ -46,10 +47,10 @@ public abstract class DiscordCommandBase : ICommand
         }
 #pragma warning restore CS0618
 
-        // Note about interactivity
-        if (console.IsOutputRedirected)
+        // Note about interactivity for Docker
+        if (console.IsOutputRedirected && Docker.IsRunningInDocker)
         {
-            console.Output.WriteLine(
+            console.Error.WriteLine(
                 "Note: Output streams are redirected, rich console interactions are disabled. "
                     + "If you are running this command in Docker, consider allocating a pseudo-terminal for better user experience (docker run -it ...)."
             );

--- a/DiscordChatExporter.Core/Utils/Docker.cs
+++ b/DiscordChatExporter.Core/Utils/Docker.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace DiscordChatExporter.Core.Utils;
+
+public static class Docker
+{
+    public static bool IsRunningInDocker { get; } =
+        Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER") == "true";
+}


### PR DESCRIPTION
Since this is the only likely scenario where that warning is useful, don't show it anywhere else.