### PR TITLE
Add `DiscordChatExporter.Cli.sh` for simpler usage from shell

### DIFF
--- a/DiscordChatExporter.Cli/DiscordChatExporter.Cli.csproj
+++ b/DiscordChatExporter.Cli/DiscordChatExporter.Cli.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="DiscordChatExporter.Cli.sh" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <PackageReference Include="CliFx" Version="2.3.5" />
     <PackageReference Include="CSharpier.MsBuild" Version="0.26.7" PrivateAssets="all" />
     <PackageReference Include="Deorcify" Version="1.0.2" PrivateAssets="all" />

--- a/DiscordChatExporter.Cli/DiscordChatExporter.Cli.sh
+++ b/DiscordChatExporter.Cli/DiscordChatExporter.Cli.sh
@@ -1,0 +1,1 @@
+dotnet DiscordChatExporter.Cli.dll "$@"


### PR DESCRIPTION
This makes it possible to run DCE.CLI like so:

```console
$ ./DiscordChatExporter.Cli.sh export ...
```

Instead of:

```console
$ dotnet DiscordChatExporter.Cli.dll export ...
```

The script file will be automatically packaged with releases.