### PR TITLE
Remove unnecessary whitespaces at the end of reactions in PlainText

### DIFF
--- a/DiscordChatExporter.Core/Exporting/PlainTextMessageWriter.cs
+++ b/DiscordChatExporter.Core/Exporting/PlainTextMessageWriter.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DiscordChatExporter.Core.Discord.Data;
 using DiscordChatExporter.Core.Discord.Data.Embeds;
+using DiscordChatExporter.Core.Utils.Extensions;
 
 namespace DiscordChatExporter.Core.Exporting;
 
@@ -172,9 +173,14 @@ internal class PlainTextMessageWriter(Stream stream, ExportContext context)
 
         await _writer.WriteLineAsync("{Reactions}");
 
-        foreach (var reaction in reactions)
+        foreach (var (reaction, i) in reactions.WithIndex())
         {
             cancellationToken.ThrowIfCancellationRequested();
+
+            if (i > 0)
+            {
+                await _writer.WriteAsync(' ');
+            }
 
             await _writer.WriteAsync(reaction.Emoji.Name);
 
@@ -182,8 +188,6 @@ internal class PlainTextMessageWriter(Stream stream, ExportContext context)
             {
                 await _writer.WriteAsync($" ({reaction.Count})");
             }
-
-            await _writer.WriteAsync(' ');
         }
 
         await _writer.WriteLineAsync();


### PR DESCRIPTION
Fixes an issue where unnecessary spaces are inserted at the end of the reaction when "TXT" is specified as the output type.

Closes #1212
