### PR TITLE
Improve documentation

### DIFF
--- a/.docs/Getting-started.md
+++ b/.docs/Getting-started.md
@@ -35,7 +35,7 @@ You can open `.html` files with a web browser, such as Google Chrome.
 
 > **Warning**:
 > If a picture is deleted, or if a user changes its avatar, the respective images will no longer be displayed.
-> Export using the "Download referenced assets" (`--media`) option to avoid this.
+> Export using the "Download assets" (`--media`) option to avoid this.
 
 ### Plain Text
 

--- a/.docs/Getting-started.md
+++ b/.docs/Getting-started.md
@@ -41,7 +41,7 @@ You can open `.html` files with a web browser, such as Google Chrome.
 
 <img src="https://i.imgur.com/PbUyRXD.png" height="400"/>
 
-The Plain Text format is the best option for archiving due to its small size.
+The Plain Text format formats messages as plain text, and has the smallest size.
 You can open `.txt` files with a text editor, such as Notepad.
 
 ### JSON

--- a/.docs/Using-the-CLI.md
+++ b/.docs/Using-the-CLI.md
@@ -12,13 +12,12 @@ After extracting the `.zip`, open Command Prompt, aka `cmd` (`Terminal` on **mac
 
 ## Step 2
 
-Change the current directory to DCE's folder with `cd C:\path\to\directory`, then press ENTER to run the command.
+Change the current directory to DCE's folder with `cd C:\path\to\DiscordChatExporter` (`cd /path/to/DiscordChatExporter` on **MacOS** and **Linux**), then press ENTER to run the command.
 
-**Windows** users can quickly get the directory's path by clicking the address bar while inside the folder.
+**Windows** users can quickly get the folder's path by clicking the address bar while inside the folder.
 ![Copy path from Explorer](https://i.imgur.com/XncnhC2.gif)
 
-**macOS** users can select the `.exe`, hit Command+I (⌘I), and copy what's after `Where:` to get the directory
-![Mac info panel](https://camo.githubusercontent.com/3c51a904b0099c9f68a4797461d4a7914902fc04/68747470733a2f2f692e696d6775722e636f6d2f323975364e79782e706e67)
+**macOS** users can press Command+Option+C (⌘⌥C) while inside the folder (or selecting it) to copy its path to the clipboard.
 
 You can also drag and drop the folder on **every platform**.
 ![Drag and drop folder](https://i.imgur.com/sOpZQAb.gif)

--- a/.docs/Using-the-GUI.md
+++ b/.docs/Using-the-GUI.md
@@ -61,38 +61,30 @@ In this screen you can customize the following:
 
 ## Settings
 
-- **Auto-update**
-Perform automatic updates on every launch.
+- **Auto-update** - Perform automatic updates on every launch.
 Default: Enabled
 
   > **Note**:
   > Keep this option enabled to receive the latest features and bug fixes!
 
-- **Dark mode**
-Use darker colors in the UI (User Interface).
+- **Dark mode** - Use darker colors in the UI (User Interface).
 Default: Disabled
 
-- **Persist token**
-Persist last used token between sessions.
+- **Persist token** - Persist last used token between sessions.
 Default: Enabled
 
-- **Show threads**
-Controls whether threads are shown in the channel list.
+- **Show threads** - Controls whether threads are shown in the channel list.
 Default: none
 
-- **Locale**
-Customize how dates are formatted in the exported files.
+- **Locale** - Customize how dates are formatted in the exported files.
 
-- **Date format**
-Customize how dates are formatted in the exported files in the settings menu ().
+- **Date format** - Customize how dates are formatted in the exported files in the settings menu ().
 
-- **Parallel limit**
-The number of channels that will be exported at the same time.
+- **Parallel limit** - The number of channels that will be exported at the same time.
 Default: 1
 
   > **Note**:
   > Try to keep this number low so that your account doesn't get flagged.
 
-- **Normalize to UTC**
-Convert all dates to UTC before exporting.
+- **Normalize to UTC** - Convert all dates to UTC before exporting.
 

--- a/.docs/Using-the-GUI.md
+++ b/.docs/Using-the-GUI.md
@@ -90,8 +90,9 @@ Customize how dates are formatted in the exported files in the settings menu ().
 The number of channels that will be exported at the same time.
 Default: 1
 
+  > **Note**:
+  > Try to keep this number low so that your account doesn't get flagged.
+
 - **Normalize to UTC**
 Convert all dates to UTC before exporting.
 
-  > **Note**:
-  > Try to keep this number low so that your account doesn't get flagged.

--- a/.docs/Using-the-GUI.md
+++ b/.docs/Using-the-GUI.md
@@ -10,7 +10,7 @@
 
 ### Step 1
 
-After extracting the `.zip`, open `DiscordChatExporter.exe`
+After extracting the `.zip`, run `DiscordChatExporter.exe` (Windows), or `DiscordChatExporter` (Mac OS and Linux).
 
 ### Step 2
 


### PR DESCRIPTION
This PR makes a few small improvements to the docs:
- Changes "Download referenced assets" to the correct "Download assets"
- Changes the description in the plain text format section to not say it's the best for archiving (file sizes of both plain text and JSON are very small, and JSON has far more data)
- Changes the GUI instructions to be cross-platform
- Makes the formatting in the GUI settings list consistent and fixed a note being in the wrong spot
- Makes the CLI instructions for changing directories clearer