### PR TITLE
Publish trimmed builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,7 +99,7 @@ jobs:
             # GUI assets aren't suffixed, unlike the CLI assets
             asset: DiscordChatExporter
 
-    runs-on: ${{ contains(matrix.rid, 'win') && 'windows-latest' || contains(matrix.rid, 'osx') && 'macos-latest' || 'ubuntu-latest' }}
+    runs-on: ${{ startsWith(matrix.rid, 'win-') && 'windows-latest' || startsWith(matrix.rid, 'osx-') && 'macos-latest' || 'ubuntu-latest' }}
     timeout-minutes: 10
 
     permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,7 +99,7 @@ jobs:
             # GUI assets aren't suffixed, unlike the CLI assets
             asset: DiscordChatExporter
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ contains(matrix.rid, 'win') && 'windows-latest' || contains(matrix.rid, 'osx') && 'macos-latest' || 'ubuntu-latest' }}
     timeout-minutes: 10
 
     permissions:

--- a/DiscordChatExporter.Cli/DiscordChatExporter.Cli.csproj
+++ b/DiscordChatExporter.Cli/DiscordChatExporter.Cli.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ApplicationIcon>..\favicon.ico</ApplicationIcon>
+    <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
   
   <ItemGroup>

--- a/DiscordChatExporter.Cli/DiscordChatExporter.Cli.csproj
+++ b/DiscordChatExporter.Cli/DiscordChatExporter.Cli.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <ApplicationIcon>..\favicon.ico</ApplicationIcon>
     <PublishTrimmed>true</PublishTrimmed>
+    <NoWarn>$(NoWarn);IL2104</NoWarn>
   </PropertyGroup>
   
   <ItemGroup>

--- a/DiscordChatExporter.Cli/Program.cs
+++ b/DiscordChatExporter.Cli/Program.cs
@@ -1,3 +1,37 @@
-﻿using CliFx;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using CliFx;
+using DiscordChatExporter.Cli.Commands;
+using DiscordChatExporter.Cli.Commands.Converters;
 
-return await new CliApplicationBuilder().AddCommandsFromThisAssembly().Build().RunAsync(args);
+namespace DiscordChatExporter.Cli;
+
+public static class Program
+{
+    // Explicit references because CliFx relies on reflection and we're publishing with trimming enabled
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(ExportAllCommand))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(ExportChannelsCommand))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(ExportDirectMessagesCommand))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(ExportGuildCommand))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(GetChannelsCommand))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(GetDirectChannelsCommand))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(GetGuildsCommand))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(GuideCommand))]
+    [DynamicDependency(
+        DynamicallyAccessedMemberTypes.All,
+        typeof(ThreadInclusionModeBindingConverter)
+    )]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(TruthyBooleanBindingConverter))]
+    public static async Task<int> Main(string[] args) =>
+        await new CliApplicationBuilder()
+            .AddCommand<ExportAllCommand>()
+            .AddCommand<ExportChannelsCommand>()
+            .AddCommand<ExportDirectMessagesCommand>()
+            .AddCommand<ExportGuildCommand>()
+            .AddCommand<GetChannelsCommand>()
+            .AddCommand<GetDirectChannelsCommand>()
+            .AddCommand<GetGuildsCommand>()
+            .AddCommand<GuideCommand>()
+            .Build()
+            .RunAsync(args);
+}

--- a/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
+++ b/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
@@ -5,8 +5,6 @@
     <AssemblyName>DiscordChatExporter</AssemblyName>
     <ApplicationIcon>..\favicon.ico</ApplicationIcon>
     <PublishTrimmed>true</PublishTrimmed>
-    <!-- AOT is supported only on x64 and arm64 -->
-    <PublishAot Condition="$(RuntimeIdentifier.Contains('x64')) OR $(RuntimeIdentifier.Contains('arm64'))">true</PublishAot>
   </PropertyGroup>
   
   <!-- Avalonia-related settings -->

--- a/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
+++ b/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
@@ -18,6 +18,8 @@
     <NoWarn>$(NoWarn);IL2104</NoWarn>
     <!-- Warnings about Material.Avalonia having peer dependencies that we don't use -->
     <NoWarn>$(NoWarn);IL2035</NoWarn>
+    <!-- Onova -->
+    <NoWarn>$(NoWarn);IL3000</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
+++ b/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
@@ -8,7 +8,7 @@
     <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
     <NoWarn>$(NoWarn);IL2104</NoWarn>
   </PropertyGroup>
-  
+
   <!-- Avalonia-related settings -->
   <PropertyGroup>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
@@ -38,7 +38,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Onova" Version="2.6.11" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\DiscordChatExporter.Core\DiscordChatExporter.Core.csproj" />
   </ItemGroup>

--- a/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
+++ b/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>DiscordChatExporter</AssemblyName>
     <ApplicationIcon>..\favicon.ico</ApplicationIcon>
     <PublishTrimmed>true</PublishTrimmed>
-    <PublishAot Condition="$(RuntimeIdentifier.Contains('x64')) OR $(RuntimeIdentifier.Contains('arm64'))">true</PublishAot>
     <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
   
@@ -18,8 +17,6 @@
     <NoWarn>$(NoWarn);IL2104</NoWarn>
     <!-- Warnings about Material.Avalonia having peer dependencies that we don't use -->
     <NoWarn>$(NoWarn);IL2035</NoWarn>
-    <!-- Onova -->
-    <NoWarn>$(NoWarn);IL3000;IL3053</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -43,14 +40,6 @@
     <PackageReference Include="Onova" Version="2.6.11" />
   </ItemGroup>
   
-  <!-- Cross-architecture compilation -->
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="9.0.0-preview.1.24080.9" PrivateAssets="all" />
-    <PackageReference Include="runtime.win-x64.Microsoft.DotNet.ILCompiler" Version="9.0.0-preview.1.24080.9" PrivateAssets="all" />
-    <PackageReference Include="runtime.linux-x64.Microsoft.DotNet.ILCompiler" Version="9.0.0-preview.1.24080.9" PrivateAssets="all" />
-    <PackageReference Include="runtime.osx-arm64.Microsoft.DotNet.ILCompiler" Version="9.0.0-preview.1.24080.9" PrivateAssets="all" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\DiscordChatExporter.Core\DiscordChatExporter.Core.csproj" />
   </ItemGroup>

--- a/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
+++ b/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
@@ -44,6 +44,9 @@
   <!-- Cross-architecture compilation -->
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="9.0.0-preview.1.24080.9" PrivateAssets="all" />
+    <PackageReference Include="runtime.win-x64.Microsoft.DotNet.ILCompiler" Version="9.0.0-preview.1.24080.9" PrivateAssets="all" />
+    <PackageReference Include="runtime.linux-x64.Microsoft.DotNet.ILCompiler" Version="9.0.0-preview.1.24080.9" PrivateAssets="all" />
+    <PackageReference Include="runtime.osx-arm64.Microsoft.DotNet.ILCompiler" Version="9.0.0-preview.1.24080.9" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
+++ b/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
@@ -6,6 +6,7 @@
     <ApplicationIcon>..\favicon.ico</ApplicationIcon>
     <PublishTrimmed>true</PublishTrimmed>
     <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
+    <NoWarn>$(NoWarn);IL2104</NoWarn>
   </PropertyGroup>
   
   <!-- Avalonia-related settings -->
@@ -13,8 +14,6 @@
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     <!-- Warnings not valid when using compiled bindings -->
     <NoWarn>$(NoWarn);IL2026</NoWarn>
-    <!-- Warnings about referenced assemblies not being fully trim-compatible -->
-    <NoWarn>$(NoWarn);IL2104</NoWarn>
     <!-- Warnings about Material.Avalonia having peer dependencies that we don't use -->
     <NoWarn>$(NoWarn);IL2035</NoWarn>
   </PropertyGroup>

--- a/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
+++ b/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>DiscordChatExporter</AssemblyName>
     <ApplicationIcon>..\favicon.ico</ApplicationIcon>
     <PublishTrimmed>true</PublishTrimmed>
+    <PublishAot Condition="$(RuntimeIdentifier.Contains('x64')) OR $(RuntimeIdentifier.Contains('arm64'))">true</PublishAot>
     <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
   
@@ -38,6 +39,12 @@
     <PackageReference Include="Material.Icons.Avalonia" Version="2.1.9" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Onova" Version="2.6.11" />
+  </ItemGroup>
+  
+  <!-- Cross-architecture compilation -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="8.0.5" PrivateAssets="all" />
+    <PackageReference Include="runtime.linux-arm64.Microsoft.DotNet.ILCompiler" Version="8.0.5" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
+++ b/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
@@ -43,8 +43,7 @@
   
   <!-- Cross-architecture compilation -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="8.0.5" PrivateAssets="all" />
-    <PackageReference Include="runtime.linux-arm64.Microsoft.DotNet.ILCompiler" Version="8.0.5" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="9.0.0-preview.1.24080.9" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
+++ b/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
@@ -4,7 +4,18 @@
     <OutputType>WinExe</OutputType>
     <AssemblyName>DiscordChatExporter</AssemblyName>
     <ApplicationIcon>..\favicon.ico</ApplicationIcon>
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
+  
+  <!-- Avalonia-related settings -->
+  <PropertyGroup>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+    <!-- Warnings not valid when using compiled bindings -->
+    <NoWarn>$(NoWarn);IL2026</NoWarn>
+    <!-- Warnings about referenced assemblies not being fully trim-compatible -->
+    <NoWarn>$(NoWarn);IL2104</NoWarn>
+    <!-- Warnings about Material.Avalonia having peer dependencies that we don't use -->
+    <NoWarn>$(NoWarn);IL2035</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
+++ b/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
@@ -4,7 +4,9 @@
     <OutputType>WinExe</OutputType>
     <AssemblyName>DiscordChatExporter</AssemblyName>
     <ApplicationIcon>..\favicon.ico</ApplicationIcon>
-    <PublishAot>true</PublishAot>
+    <PublishTrimmed>true</PublishTrimmed>
+    <!-- AOT is supported only on x64 and arm64 -->
+    <PublishAot Condition="$(RuntimeIdentifier).Contains('x64') OR $(RuntimeIdentifier).Contains('arm64')">true</PublishAot>
   </PropertyGroup>
   
   <!-- Avalonia-related settings -->

--- a/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
+++ b/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
@@ -4,6 +4,7 @@
     <OutputType>WinExe</OutputType>
     <AssemblyName>DiscordChatExporter</AssemblyName>
     <ApplicationIcon>..\favicon.ico</ApplicationIcon>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
+++ b/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
@@ -6,7 +6,7 @@
     <ApplicationIcon>..\favicon.ico</ApplicationIcon>
     <PublishTrimmed>true</PublishTrimmed>
     <!-- AOT is supported only on x64 and arm64 -->
-    <PublishAot Condition="$(RuntimeIdentifier).Contains('x64') OR $(RuntimeIdentifier).Contains('arm64')">true</PublishAot>
+    <PublishAot Condition="$(RuntimeIdentifier.Contains('x64')) OR $(RuntimeIdentifier.Contains('arm64'))">true</PublishAot>
   </PropertyGroup>
   
   <!-- Avalonia-related settings -->

--- a/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
+++ b/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>DiscordChatExporter</AssemblyName>
     <ApplicationIcon>..\favicon.ico</ApplicationIcon>
     <PublishTrimmed>true</PublishTrimmed>
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
   
   <!-- Avalonia-related settings -->

--- a/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
+++ b/DiscordChatExporter.Gui/DiscordChatExporter.Gui.csproj
@@ -19,7 +19,7 @@
     <!-- Warnings about Material.Avalonia having peer dependencies that we don't use -->
     <NoWarn>$(NoWarn);IL2035</NoWarn>
     <!-- Onova -->
-    <NoWarn>$(NoWarn);IL3000</NoWarn>
+    <NoWarn>$(NoWarn);IL3000;IL3053</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DiscordChatExporter.Gui/Framework/ViewManager.cs
+++ b/DiscordChatExporter.Gui/Framework/ViewManager.cs
@@ -14,11 +14,11 @@ public partial class ViewManager
     private Control? TryCreateView(ViewModelBase viewModel) =>
         viewModel switch
         {
+            MainViewModel => new MainView(),
             DashboardViewModel => new DashboardView(),
             ExportSetupViewModel => new ExportSetupView(),
             MessageBoxViewModel => new MessageBoxView(),
             SettingsViewModel => new SettingsView(),
-            MainViewModel => new MainView(),
             _ => null
         };
 

--- a/DiscordChatExporter.Gui/Framework/ViewManager.cs
+++ b/DiscordChatExporter.Gui/Framework/ViewManager.cs
@@ -1,25 +1,31 @@
-﻿using System;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Controls.Templates;
+using DiscordChatExporter.Gui.ViewModels;
+using DiscordChatExporter.Gui.ViewModels.Components;
+using DiscordChatExporter.Gui.ViewModels.Dialogs;
+using DiscordChatExporter.Gui.Views;
+using DiscordChatExporter.Gui.Views.Components;
+using DiscordChatExporter.Gui.Views.Dialogs;
 
 namespace DiscordChatExporter.Gui.Framework;
 
 public partial class ViewManager
 {
+    private Control? TryCreateView(ViewModelBase viewModel) =>
+        viewModel switch
+        {
+            DashboardViewModel => new DashboardView(),
+            ExportSetupViewModel => new ExportSetupView(),
+            MessageBoxViewModel => new MessageBoxView(),
+            SettingsViewModel => new SettingsView(),
+            MainViewModel => new MainView(),
+            _ => null
+        };
+
     public Control? TryBindView(ViewModelBase viewModel)
     {
-        var name = viewModel
-            .GetType()
-            .FullName?.Replace("ViewModel", "View", StringComparison.Ordinal);
-
-        if (string.IsNullOrWhiteSpace(name))
-            return null;
-
-        var type = Type.GetType(name);
-        if (type is null)
-            return null;
-
-        if (Activator.CreateInstance(type) is not Control view)
+        var view = TryCreateView(viewModel);
+        if (view is null)
             return null;
 
         view.DataContext ??= viewModel;

--- a/DiscordChatExporter.Gui/Services/SettingsService.cs
+++ b/DiscordChatExporter.Gui/Services/SettingsService.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using Cogwheel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using DiscordChatExporter.Core.Exporting;
@@ -13,8 +11,7 @@ namespace DiscordChatExporter.Gui.Services;
 [INotifyPropertyChanged]
 public partial class SettingsService()
     : SettingsBase(
-        Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Settings.dat"),
-        new JsonSerializerOptions { TypeInfoResolver = SerializerContext.Default }
+        Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Settings.dat")
     )
 {
     [ObservableProperty]
@@ -76,10 +73,4 @@ public partial class SettingsService()
 
         LastToken = lastToken;
     }
-}
-
-public partial class SettingsService
-{
-    [JsonSerializable(typeof(SettingsService))]
-    private partial class SerializerContext : JsonSerializerContext;
 }

--- a/DiscordChatExporter.Gui/Services/SettingsService.cs
+++ b/DiscordChatExporter.Gui/Services/SettingsService.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Cogwheel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using DiscordChatExporter.Core.Exporting;
@@ -10,7 +12,10 @@ namespace DiscordChatExporter.Gui.Services;
 
 [INotifyPropertyChanged]
 public partial class SettingsService()
-    : SettingsBase(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Settings.dat"))
+    : SettingsBase(
+        Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Settings.dat"),
+        new JsonSerializerOptions { TypeInfoResolver = SerializerContext.Default }
+    )
 {
     [ObservableProperty]
     private bool _isUkraineSupportMessageEnabled = true;
@@ -71,4 +76,10 @@ public partial class SettingsService()
 
         LastToken = lastToken;
     }
+}
+
+public partial class SettingsService
+{
+    [JsonSerializable(typeof(SettingsService))]
+    private partial class SerializerContext : JsonSerializerContext;
 }

--- a/DiscordChatExporter.Gui/Services/SettingsService.cs
+++ b/DiscordChatExporter.Gui/Services/SettingsService.cs
@@ -10,9 +10,7 @@ namespace DiscordChatExporter.Gui.Services;
 
 [INotifyPropertyChanged]
 public partial class SettingsService()
-    : SettingsBase(
-        Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Settings.dat")
-    )
+    : SettingsBase(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Settings.dat"))
 {
     [ObservableProperty]
     private bool _isUkraineSupportMessageEnabled = true;

--- a/DiscordChatExporter.Gui/Views/Components/DashboardView.axaml
+++ b/DiscordChatExporter.Gui/Views/Components/DashboardView.axaml
@@ -9,11 +9,8 @@
     xmlns:materialIcons="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
     xmlns:materialStyles="clr-namespace:Material.Styles.Controls;assembly=Material.Styles"
     x:Name="UserControl"
+    x:DataType="components:DashboardViewModel"
     Loaded="UserControl_OnLoaded">
-    <Design.DataContext>
-        <components:DashboardViewModel />
-    </Design.DataContext>
-
     <DockPanel>
         <!--  Header  -->
         <StackPanel
@@ -95,126 +92,6 @@
                     </Style>
                 </Style>
             </Panel.Styles>
-            <!--  Placeholder / usage instructions  -->
-            <Panel IsVisible="{Binding !AvailableGuilds.Count}">
-                <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
-                    <TextBlock
-                        Margin="32,16"
-                        FontSize="14"
-                        FontWeight="Light"
-                        LineHeight="23">
-                        <!--  User token  -->
-                        <InlineUIContainer>
-                            <materialIcons:MaterialIcon
-                                Width="18"
-                                Height="18"
-                                Margin="0,-2,0,0"
-                                Foreground="{DynamicResource PrimaryHueMidBrush}"
-                                Kind="Account" />
-                        </InlineUIContainer>
-                        <Run Text="" />
-                        <Run
-                            FontSize="16"
-                            FontWeight="SemiBold"
-                            Text="To get the token for your personal account:" />
-                        <LineBreak />
-
-                        <Run Text="*  Automating user accounts is technically against TOS —" />
-                        <Run FontWeight="SemiBold" Text="use at your own risk" /><Run Text="!" />
-                        <LineBreak />
-
-                        <Run Text="1. Open Discord in your" />
-                        <controls:HyperLink Command="{Binding OpenDiscordCommand}" Text="web browser" />
-                        <Run Text="and login" />
-                        <LineBreak />
-
-                        <Run Text="2. Open any server or direct message channel" />
-                        <LineBreak />
-
-                        <Run Text="3. Press" />
-                        <Run FontWeight="SemiBold" Text="Ctrl+Shift+I" />
-                        <Run Text="to show developer tools" />
-                        <LineBreak />
-
-                        <Run Text="4. Navigate to the" />
-                        <Run FontWeight="SemiBold" Text="Network" />
-                        <Run Text="tab" />
-                        <LineBreak />
-
-                        <Run Text="5. Press" />
-                        <Run FontWeight="SemiBold" Text="Ctrl+R" />
-                        <Run Text="to reload" />
-                        <LineBreak />
-
-                        <Run Text="6. Switch between random channels to trigger network requests" />
-                        <LineBreak />
-
-                        <Run Text="7. Search for a request that starts with" />
-                        <Run FontWeight="SemiBold" Text="messages" />
-                        <LineBreak />
-
-                        <Run Text="8. Select the" />
-                        <Run FontWeight="SemiBold" Text="Headers" />
-                        <Run Text="tab on the right" />
-                        <LineBreak />
-
-                        <Run Text="9. Scroll down to the" />
-                        <Run FontWeight="SemiBold" Text="Request Headers" />
-                        <Run Text="section" />
-                        <LineBreak />
-
-                        <Run Text="10. Copy the value of the" />
-                        <Run FontWeight="SemiBold" Text="authorization" />
-                        <Run Text="header" />
-                        <LineBreak />
-                        <LineBreak />
-
-                        <!--  Bot token  -->
-                        <InlineUIContainer>
-                            <materialIcons:MaterialIcon
-                                Width="18"
-                                Height="18"
-                                Margin="0,-2,0,0"
-                                Foreground="{DynamicResource PrimaryHueMidBrush}"
-                                Kind="Robot" />
-                        </InlineUIContainer>
-                        <Run Text="" />
-                        <Run
-                            FontSize="16"
-                            FontWeight="SemiBold"
-                            Text="To get the token for your bot:" />
-                        <LineBreak />
-
-                        <Run Text="1. Open Discord" />
-                        <controls:HyperLink Command="{Binding OpenDiscordDeveloperPortalCommand}" Text="developer portal" />
-                        <LineBreak />
-
-                        <Run Text="2. Open your application's settings" />
-                        <LineBreak />
-
-                        <Run Text="3. Navigate to the" />
-                        <Run FontWeight="SemiBold" Text="Bot" />
-                        <Run Text="section on the left" />
-                        <LineBreak />
-
-                        <Run Text="4. Under" />
-                        <Run FontWeight="SemiBold" Text="Token" />
-                        <Run Text="click" />
-                        <Run FontWeight="SemiBold" Text="Copy" />
-                        <LineBreak />
-
-                        <Run Text="*  Your bot needs to have the" />
-                        <Run FontWeight="SemiBold" Text="Message Content Intent" />
-                        <Run Text="enabled to read messages" />
-                        <LineBreak />
-                        <LineBreak />
-
-                        <Run Text="If you have questions or issues, please refer to the" />
-                        <controls:HyperLink Command="{Binding ShowHelpCommand}" Text="documentation" />
-                    </TextBlock>
-                </ScrollViewer>
-            </Panel>
-
             <!--  Guilds and channels  -->
             <Grid ColumnDefinitions="Auto,*" IsVisible="{Binding !!AvailableGuilds.Count}">
                 <!--  Guilds  -->
@@ -338,6 +215,126 @@
                     </TreeView>
                 </Border>
             </Grid>
+
+            <!--  Placeholder / usage instructions  -->
+            <Panel IsVisible="{Binding !AvailableGuilds.Count}">
+                <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+                    <TextBlock
+                        Margin="32,16"
+                        FontSize="14"
+                        FontWeight="Light"
+                        LineHeight="23">
+                        <!--  User token  -->
+                        <InlineUIContainer>
+                            <materialIcons:MaterialIcon
+                                Width="18"
+                                Height="18"
+                                Margin="0,-2,0,0"
+                                Foreground="{DynamicResource PrimaryHueMidBrush}"
+                                Kind="Account" />
+                        </InlineUIContainer>
+                        <Run Text="" />
+                        <Run
+                            FontSize="16"
+                            FontWeight="SemiBold"
+                            Text="To get the token for your personal account:" />
+                        <LineBreak />
+
+                        <Run Text="*  Automating user accounts is technically against TOS —" />
+                        <Run FontWeight="SemiBold" Text="use at your own risk" /><Run Text="!" />
+                        <LineBreak />
+
+                        <Run Text="1. Open Discord in your" />
+                        <controls:HyperLink Command="{Binding OpenDiscordCommand}" Text="web browser" />
+                        <Run Text="and login" />
+                        <LineBreak />
+
+                        <Run Text="2. Open any server or direct message channel" />
+                        <LineBreak />
+
+                        <Run Text="3. Press" />
+                        <Run FontWeight="SemiBold" Text="Ctrl+Shift+I" />
+                        <Run Text="to show developer tools" />
+                        <LineBreak />
+
+                        <Run Text="4. Navigate to the" />
+                        <Run FontWeight="SemiBold" Text="Network" />
+                        <Run Text="tab" />
+                        <LineBreak />
+
+                        <Run Text="5. Press" />
+                        <Run FontWeight="SemiBold" Text="Ctrl+R" />
+                        <Run Text="to reload" />
+                        <LineBreak />
+
+                        <Run Text="6. Switch between random channels to trigger network requests" />
+                        <LineBreak />
+
+                        <Run Text="7. Search for a request that starts with" />
+                        <Run FontWeight="SemiBold" Text="messages" />
+                        <LineBreak />
+
+                        <Run Text="8. Select the" />
+                        <Run FontWeight="SemiBold" Text="Headers" />
+                        <Run Text="tab on the right" />
+                        <LineBreak />
+
+                        <Run Text="9. Scroll down to the" />
+                        <Run FontWeight="SemiBold" Text="Request Headers" />
+                        <Run Text="section" />
+                        <LineBreak />
+
+                        <Run Text="10. Copy the value of the" />
+                        <Run FontWeight="SemiBold" Text="authorization" />
+                        <Run Text="header" />
+                        <LineBreak />
+                        <LineBreak />
+
+                        <!--  Bot token  -->
+                        <InlineUIContainer>
+                            <materialIcons:MaterialIcon
+                                Width="18"
+                                Height="18"
+                                Margin="0,-2,0,0"
+                                Foreground="{DynamicResource PrimaryHueMidBrush}"
+                                Kind="Robot" />
+                        </InlineUIContainer>
+                        <Run Text="" />
+                        <Run
+                            FontSize="16"
+                            FontWeight="SemiBold"
+                            Text="To get the token for your bot:" />
+                        <LineBreak />
+
+                        <Run Text="1. Open Discord" />
+                        <controls:HyperLink Command="{Binding OpenDiscordDeveloperPortalCommand}" Text="developer portal" />
+                        <LineBreak />
+
+                        <Run Text="2. Open your application's settings" />
+                        <LineBreak />
+
+                        <Run Text="3. Navigate to the" />
+                        <Run FontWeight="SemiBold" Text="Bot" />
+                        <Run Text="section on the left" />
+                        <LineBreak />
+
+                        <Run Text="4. Under" />
+                        <Run FontWeight="SemiBold" Text="Token" />
+                        <Run Text="click" />
+                        <Run FontWeight="SemiBold" Text="Copy" />
+                        <LineBreak />
+
+                        <Run Text="*  Your bot needs to have the" />
+                        <Run FontWeight="SemiBold" Text="Message Content Intent" />
+                        <Run Text="enabled to read messages" />
+                        <LineBreak />
+                        <LineBreak />
+
+                        <Run Text="If you have questions or issues, please refer to the" />
+                        <controls:HyperLink Command="{Binding ShowHelpCommand}" Text="documentation" />
+                    </TextBlock>
+                </ScrollViewer>
+            </Panel>
 
             <!--  Export button  -->
             <Button

--- a/DiscordChatExporter.Gui/Views/Controls/HyperLink.axaml
+++ b/DiscordChatExporter.Gui/Views/Controls/HyperLink.axaml
@@ -1,13 +1,14 @@
 ﻿<UserControl
     x:Class="DiscordChatExporter.Gui.Views.Controls.HyperLink"
     xmlns="https://github.com/avaloniaui"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="clr-namespace:DiscordChatExporter.Gui.Views.Controls">
     <TextBlock
         x:Name="TextBlock"
         Cursor="Hand"
         Foreground="{DynamicResource MaterialSecondaryDarkBrush}"
         PointerReleased="TextBlock_OnPointerReleased"
-        Text="{Binding $parent[UserControl].Text, Mode=OneWay}">
+        Text="{Binding $parent[controls:HyperLink].Text, Mode=OneWay}">
         <TextBlock.Styles>
             <Style Selector="TextBlock">
                 <Style Selector="^:pointerover">

--- a/DiscordChatExporter.Gui/Views/Dialogs/ExportSetupView.axaml
+++ b/DiscordChatExporter.Gui/Views/Dialogs/ExportSetupView.axaml
@@ -10,11 +10,8 @@
     xmlns:utils="clr-namespace:DiscordChatExporter.Gui.Utils"
     x:Name="UserControl"
     Width="380"
+    x:DataType="dialogs:ExportSetupViewModel"
     Loaded="UserControl_OnLoaded">
-    <Design.DataContext>
-        <dialogs:ExportSetupViewModel />
-    </Design.DataContext>
-
     <Grid RowDefinitions="Auto,*,Auto">
         <!--  Guild/channel info  -->
         <Grid
@@ -40,7 +37,7 @@
                 FontWeight="Light"
                 IsVisible="{Binding !IsSingleChannel}"
                 TextTrimming="CharacterEllipsis">
-                <Run Text="{Binding Channels.Count, Mode=OneWay}" />
+                <Run Text="{Binding Channels.Count, Mode=OneWay, FallbackValue=0}" />
                 <Run Text="channels selected" />
             </TextBlock>
 

--- a/DiscordChatExporter.Gui/Views/Dialogs/ExportSetupView.axaml
+++ b/DiscordChatExporter.Gui/Views/Dialogs/ExportSetupView.axaml
@@ -37,7 +37,7 @@
                 FontWeight="Light"
                 IsVisible="{Binding !IsSingleChannel}"
                 TextTrimming="CharacterEllipsis">
-                <Run Text="{Binding Channels.Count, Mode=OneWay, FallbackValue=0}" />
+                <Run Text="{Binding Channels.Count, FallbackValue=0, Mode=OneWay}" />
                 <Run Text="channels selected" />
             </TextBlock>
 

--- a/DiscordChatExporter.Gui/Views/Dialogs/MessageBoxView.axaml
+++ b/DiscordChatExporter.Gui/Views/Dialogs/MessageBoxView.axaml
@@ -4,11 +4,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:dialogs="clr-namespace:DiscordChatExporter.Gui.ViewModels.Dialogs"
     xmlns:system="clr-namespace:System;assembly=System.Runtime"
-    Width="500">
-    <Design.DataContext>
-        <dialogs:MessageBoxViewModel />
-    </Design.DataContext>
-
+    Width="500"
+    x:DataType="dialogs:MessageBoxViewModel">
     <Grid RowDefinitions="Auto,*,Auto">
         <!--  Title  -->
         <TextBlock

--- a/DiscordChatExporter.Gui/Views/Dialogs/SettingsView.axaml
+++ b/DiscordChatExporter.Gui/Views/Dialogs/SettingsView.axaml
@@ -4,11 +4,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:converters="clr-namespace:DiscordChatExporter.Gui.Converters"
     xmlns:dialogs="clr-namespace:DiscordChatExporter.Gui.ViewModels.Dialogs"
-    Width="380">
-    <Design.DataContext>
-        <dialogs:SettingsViewModel />
-    </Design.DataContext>
-
+    Width="380"
+    x:DataType="dialogs:SettingsViewModel">
     <Grid RowDefinitions="Auto,*,Auto">
         <TextBlock
             Grid.Row="0"

--- a/DiscordChatExporter.Gui/Views/MainView.axaml
+++ b/DiscordChatExporter.Gui/Views/MainView.axaml
@@ -10,13 +10,10 @@
     Height="625"
     MinWidth="600"
     MinHeight="400"
+    x:DataType="viewModels:MainViewModel"
     Icon="/favicon.ico"
     RenderOptions.BitmapInterpolationMode="HighQuality"
     WindowStartupLocation="CenterScreen">
-    <Design.DataContext>
-        <viewModels:MainViewModel />
-    </Design.DataContext>
-
     <dialogHostAvalonia:DialogHost
         x:Name="DialogHost"
         CloseOnClickAway="False"


### PR DESCRIPTION
Trim published binaries to reduce their size.

This is currently done in a slightly hacky way due to many libraries producing trim warnings, including:
- Avalonia itself
- Material.Avalonia
- CliFx (uses reflection)
- Onova (uses reflection)
- Cogwheel (supports source-generation but doesn't seem to work well)