### PR TITLE
Add button in GUI to export a single channel by ID

### DIFF
--- a/DiscordChatExporter.Gui/App.axaml.cs
+++ b/DiscordChatExporter.Gui/App.axaml.cs
@@ -46,6 +46,7 @@ public class App : Application, IDisposable
         services.AddTransient<ExportSetupViewModel>();
         services.AddTransient<MessageBoxViewModel>();
         services.AddTransient<SettingsViewModel>();
+        services.AddTransient<QuickExportViewModel>();
 
         _services = services.BuildServiceProvider(true);
         _settingsService = _services.GetRequiredService<SettingsService>();

--- a/DiscordChatExporter.Gui/Framework/ViewModelManager.cs
+++ b/DiscordChatExporter.Gui/Framework/ViewModelManager.cs
@@ -50,4 +50,7 @@ public class ViewModelManager(IServiceProvider services)
 
     public SettingsViewModel CreateSettingsViewModel() =>
         services.GetRequiredService<SettingsViewModel>();
+
+    public QuickExportViewModel CreateQuickExportViewModel() =>
+        services.GetRequiredService<QuickExportViewModel>();
 }

--- a/DiscordChatExporter.Gui/ViewModels/Components/DashboardViewModel.cs
+++ b/DiscordChatExporter.Gui/ViewModels/Components/DashboardViewModel.cs
@@ -18,7 +18,6 @@ using DiscordChatExporter.Gui.Utils;
 using DiscordChatExporter.Gui.Utils.Extensions;
 using Gress;
 using Gress.Completable;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace DiscordChatExporter.Gui.ViewModels.Components;
 
@@ -250,110 +249,36 @@ public partial class DashboardViewModel : ViewModelBase
     [RelayCommand(CanExecute = nameof(CanExportSingleChannel))]
     private async Task ExportSingleChannel()
     {
+        if (_discord is null || ChannelId is null)
+            return;
         IsBusy = true;
 
-        try
-        {
-            if (_discord is null || ChannelId is null)
-                return;
+        var channel = await _discord.GetChannelAsync(Snowflake.Parse(ChannelId));
+        var guild = await _discord.GetGuildAsync(channel.GuildId);
 
-            var channel = await _discord.GetChannelAsync(Snowflake.Parse(ChannelId));
-            var guild = await _discord.GetGuildAsync(channel.GuildId);
-
-            var dialog = _viewModelManager.CreateExportSetupViewModel(guild, [channel]);
-
-            if (await _dialogManager.ShowDialogAsync(dialog) != true)
-                return;
-
-            var exporter = new ChannelExporter(_discord);
-
-            var channelProgressPairs = dialog
-                .Channels!.Select(c => new { Channel = c, Progress = _progressMuxer.CreateInput() })
-                .ToArray();
-
-            var successfulExportCount = 0;
-
-            await Parallel.ForEachAsync(
-                channelProgressPairs,
-                new ParallelOptions
-                {
-                    MaxDegreeOfParallelism = Math.Max(1, _settingsService.ParallelLimit)
-                },
-                async (pair, cancellationToken) =>
-                {
-                    var channel = pair.Channel;
-                    var progress = pair.Progress;
-
-                    try
-                    {
-                        var request = new ExportRequest(
-                            dialog.Guild!,
-                            channel,
-                            dialog.OutputPath!,
-                            dialog.AssetsDirPath,
-                            dialog.SelectedFormat,
-                            dialog.After?.Pipe(Snowflake.FromDate),
-                            dialog.Before?.Pipe(Snowflake.FromDate),
-                            dialog.PartitionLimit,
-                            dialog.MessageFilter,
-                            dialog.ShouldFormatMarkdown,
-                            dialog.ShouldDownloadAssets,
-                            dialog.ShouldReuseAssets,
-                            _settingsService.Locale,
-                            _settingsService.IsUtcNormalizationEnabled
-                        );
-
-                        await exporter.ExportChannelAsync(request, progress, cancellationToken);
-
-                        Interlocked.Increment(ref successfulExportCount);
-                    }
-                    catch (DiscordChatExporterException ex) when (!ex.IsFatal)
-                    {
-                        _snackbarManager.Notify(ex.Message.TrimEnd('.'));
-                    }
-                    finally
-                    {
-                        progress.ReportCompletion();
-                    }
-                }
-            );
-
-            // Notify of the overall completion
-            if (successfulExportCount > 0)
-            {
-                _snackbarManager.Notify(
-                    $"Successfully exported {successfulExportCount} channel(s)"
-                );
-            }
-        }
-        catch (Exception ex)
-        {
-            var dialog = _viewModelManager.CreateMessageBoxViewModel(
-                "Error exporting channel(s)",
-                ex.ToString()
-            );
-
-            await _dialogManager.ShowDialogAsync(dialog);
-        }
-        finally
-        {
-            IsBusy = false;
-        }
+        await ExportInternalAsync(guild, [channel]);
     }
 
     [RelayCommand(CanExecute = nameof(CanExport))]
     private async Task ExportAsync()
     {
-        IsBusy = true;
+        if (SelectedGuild is null || !SelectedChannels.Any())
+            return;
 
+        IsBusy = true;
+        await ExportInternalAsync(SelectedGuild, SelectedChannels.Select(c => c.Channel).ToList());
+    }
+
+    private async Task ExportInternalAsync(Guild guild, IReadOnlyList<Channel> channels)
+    {
         try
         {
-            if (_discord is null || SelectedGuild is null || !SelectedChannels.Any())
+            if (_discord is null)
                 return;
 
             var dialog = _viewModelManager.CreateExportSetupViewModel(
-                SelectedGuild,
-                SelectedChannels.Select(c => c.Channel).ToArray()
+                guild,
+                channels
             );
 
             if (await _dialogManager.ShowDialogAsync(dialog) != true)

--- a/DiscordChatExporter.Gui/ViewModels/Components/DashboardViewModel.cs
+++ b/DiscordChatExporter.Gui/ViewModels/Components/DashboardViewModel.cs
@@ -276,10 +276,7 @@ public partial class DashboardViewModel : ViewModelBase
             if (_discord is null)
                 return;
 
-            var dialog = _viewModelManager.CreateExportSetupViewModel(
-                guild,
-                channels
-            );
+            var dialog = _viewModelManager.CreateExportSetupViewModel(guild, channels);
 
             if (await _dialogManager.ShowDialogAsync(dialog) != true)
                 return;

--- a/DiscordChatExporter.Gui/ViewModels/Dialogs/QuickExportViewModel.cs
+++ b/DiscordChatExporter.Gui/ViewModels/Dialogs/QuickExportViewModel.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DiscordChatExporter.Gui.Framework;
+
+namespace DiscordChatExporter.Gui.ViewModels.Dialogs;
+
+public partial class QuickExportViewModel : DialogViewModelBase
+{
+    [ObservableProperty]
+    private string? _query;
+
+    public bool CanProcessQuery => !String.IsNullOrWhiteSpace(Query);
+
+    [RelayCommand(CanExecute = nameof(CanProcessQuery))]
+    public void ProcessQuery() { }
+}

--- a/DiscordChatExporter.Gui/Views/Components/DashboardView.axaml
+++ b/DiscordChatExporter.Gui/Views/Components/DashboardView.axaml
@@ -145,7 +145,7 @@
             </Grid>
             <!--  Progress  -->
             <ProgressBar
-                Height="4"
+                Height="2"
                 Background="Transparent"
                 IsIndeterminate="{Binding IsProgressIndeterminate}"
                 Value="{Binding Progress.Current.Fraction, Mode=OneWay}" />

--- a/DiscordChatExporter.Gui/Views/Components/DashboardView.axaml
+++ b/DiscordChatExporter.Gui/Views/Components/DashboardView.axaml
@@ -155,7 +155,6 @@
         <Panel
             Background="{DynamicResource MaterialCardBackgroundBrush}"
             DockPanel.Dock="Bottom"
-            IsVisible="{Binding !ShowPullSingleChannel}"
             IsEnabled="{Binding !IsBusy}">
             <Panel.Styles>
                 <Style Selector="Panel">

--- a/DiscordChatExporter.Gui/Views/Components/DashboardView.axaml
+++ b/DiscordChatExporter.Gui/Views/Components/DashboardView.axaml
@@ -17,7 +17,7 @@
             Background="{DynamicResource MaterialDarkBackgroundBrush}"
             DockPanel.Dock="Top"
             Orientation="Vertical">
-            <Grid Margin="12,12,8,12" ColumnDefinitions="*,Auto">
+            <Grid Margin="12,12,8,12" ColumnDefinitions="*,Auto,Auto">
                 <materialStyles:Card Grid.Column="0">
                     <!--  Token  -->
                     <TextBox
@@ -38,27 +38,58 @@
                                 Kind="Key" />
                         </TextBox.InnerLeftContent>
                         <TextBox.InnerRightContent>
-                            <Button
-                                Grid.Column="2"
+							<Button
+                                Grid.Column="1"
                                 Margin="8,0,0,0"
                                 Padding="4"
                                 Command="{Binding PullGuildsCommand}"
                                 IsDefault="True"
                                 Theme="{DynamicResource MaterialFlatButton}"
                                 ToolTip.Tip="Pull available servers and channels (Enter)">
-                                <materialIcons:MaterialIcon
+								<materialIcons:MaterialIcon
                                     Width="24"
                                     Height="24"
                                     Kind="ArrowRight" />
-                            </Button>
+							</Button>
                         </TextBox.InnerRightContent>
                     </TextBox>
                 </materialStyles:Card>
 
+				<!-- Single Channel Button-->
+				<Button
+					Grid.Column="1"
+					Margin="4,0,0,0"
+					Padding="8"
+                    VerticalAlignment="Center"
+					Command="{Binding TogglePullSingleChannelCommand}"
+					IsDefault="True"
+					Theme="{DynamicResource MaterialFlatButton}"
+					IsVisible="{Binding !ShowPullSingleChannel}"
+					ToolTip.Tip="You already have the Channel Id and just want to quickly export it">
+					<materialIcons:MaterialIcon
+						Width="24"
+						Height="24"
+						Kind="LightningBoltOutline" />
+				</Button>
+				<Button
+					Grid.Column="1"
+					Margin="4,0,0,0"
+					Padding="8"
+                    VerticalAlignment="Center"
+					Command="{Binding TogglePullSingleChannelCommand}"
+					Theme="{DynamicResource MaterialFlatButton}"
+					IsVisible="{Binding ShowPullSingleChannel}"
+					ToolTip.Tip="You already have the Channel Id and just want to quickly export it">
+					<materialIcons:MaterialIcon
+						Width="24"
+						Height="24"
+						Kind="LightningBolt" />
+				</Button>
+				
                 <!--  Settings button  -->
                 <Button
-                    Grid.Column="1"
-                    Margin="8,0,0,0"
+                    Grid.Column="2"
+                    Margin="4,0,0,0"
                     Padding="8"
                     VerticalAlignment="Center"
                     Command="{Binding ShowSettingsCommand}"
@@ -70,11 +101,51 @@
                         Height="24"
                         Kind="Settings" />
                 </Button>
-            </Grid>
+            
+			
+			</Grid>
 
-            <!--  Progress  -->
+			<!-- Single Channel Input -->
+			<Grid 
+				Margin="12,12,8,12" 
+				ColumnDefinitions="*,Auto" 
+			    IsVisible="{Binding ShowPullSingleChannel}">
+				<materialStyles:Card Grid.Column="0">
+					<!--  Channel Id  -->
+					<TextBox
+                        FontSize="16"
+                        Text="{Binding ChannelId}"
+                        Theme="{DynamicResource SoloTextBox}"
+                        Watermark="Channel Id">
+						<TextBox.InnerLeftContent>
+							<materialIcons:MaterialIcon
+                                Grid.Column="0"
+                                Width="24"
+                                Height="24"
+                                Margin="4,0,8,0"
+                                Foreground="{DynamicResource PrimaryHueMidBrush}"
+                                Kind="Forum" />
+						</TextBox.InnerLeftContent>
+						<TextBox.InnerRightContent>
+							<Button
+                                Grid.Column="1"
+                                Margin="8,0,0,0"
+                                Padding="4"
+                                Command="{Binding ExportSingleChannelCommand}"
+                                Theme="{DynamicResource MaterialFlatButton}"
+                                ToolTip.Tip="Export Channel by Id">
+								<materialIcons:MaterialIcon
+                                    Width="24"
+                                    Height="24"
+                                    Kind="ArrowRight" />
+							</Button>
+						</TextBox.InnerRightContent>
+					</TextBox>
+				</materialStyles:Card>
+			</Grid>
+				<!--  Progress  -->
             <ProgressBar
-                Height="2"
+                Height="4"
                 Background="Transparent"
                 IsIndeterminate="{Binding IsProgressIndeterminate}"
                 Value="{Binding Progress.Current.Fraction, Mode=OneWay}" />
@@ -84,6 +155,7 @@
         <Panel
             Background="{DynamicResource MaterialCardBackgroundBrush}"
             DockPanel.Dock="Bottom"
+			IsVisible="{Binding !ShowPullSingleChannel}"
             IsEnabled="{Binding !IsBusy}">
             <Panel.Styles>
                 <Style Selector="Panel">

--- a/DiscordChatExporter.Gui/Views/Components/DashboardView.axaml
+++ b/DiscordChatExporter.Gui/Views/Components/DashboardView.axaml
@@ -38,7 +38,7 @@
                                 Kind="Key" />
                         </TextBox.InnerLeftContent>
                         <TextBox.InnerRightContent>
-							<Button
+                            <Button
                                 Grid.Column="1"
                                 Margin="8,0,0,0"
                                 Padding="4"
@@ -46,17 +46,17 @@
                                 IsDefault="True"
                                 Theme="{DynamicResource MaterialFlatButton}"
                                 ToolTip.Tip="Pull available servers and channels (Enter)">
-								<materialIcons:MaterialIcon
+                                <materialIcons:MaterialIcon
                                     Width="24"
                                     Height="24"
                                     Kind="ArrowRight" />
-							</Button>
+                            </Button>
                         </TextBox.InnerRightContent>
                     </TextBox>
                 </materialStyles:Card>
 
-				<!-- Single Channel Button-->
-				<Button
+                <!-- Single Channel Button-->
+                <Button
 					Grid.Column="1"
 					Margin="4,0,0,0"
 					Padding="8"
@@ -66,12 +66,12 @@
 					Theme="{DynamicResource MaterialFlatButton}"
 					IsVisible="{Binding !ShowPullSingleChannel}"
 					ToolTip.Tip="You already have the Channel Id and just want to quickly export it">
-					<materialIcons:MaterialIcon
+                    <materialIcons:MaterialIcon
 						Width="24"
 						Height="24"
 						Kind="LightningBoltOutline" />
-				</Button>
-				<Button
+                </Button>
+                <Button
 					Grid.Column="1"
 					Margin="4,0,0,0"
 					Padding="8"
@@ -80,12 +80,12 @@
 					Theme="{DynamicResource MaterialFlatButton}"
 					IsVisible="{Binding ShowPullSingleChannel}"
 					ToolTip.Tip="You already have the Channel Id and just want to quickly export it">
-					<materialIcons:MaterialIcon
+                    <materialIcons:MaterialIcon
 						Width="24"
 						Height="24"
 						Kind="LightningBolt" />
-				</Button>
-				
+                </Button>
+
                 <!--  Settings button  -->
                 <Button
                     Grid.Column="2"
@@ -101,49 +101,49 @@
                         Height="24"
                         Kind="Settings" />
                 </Button>
-            
-			
-			</Grid>
 
-			<!-- Single Channel Input -->
-			<Grid 
-				Margin="12,12,8,12" 
-				ColumnDefinitions="*,Auto" 
+
+            </Grid>
+
+            <!-- Single Channel Input -->
+            <Grid
+				Margin="12,12,8,12"
+				ColumnDefinitions="*,Auto"
 			    IsVisible="{Binding ShowPullSingleChannel}">
-				<materialStyles:Card Grid.Column="0">
-					<!--  Channel Id  -->
-					<TextBox
+                <materialStyles:Card Grid.Column="0">
+                    <!--  Channel Id  -->
+                    <TextBox
                         FontSize="16"
                         Text="{Binding ChannelId}"
                         Theme="{DynamicResource SoloTextBox}"
                         Watermark="Channel Id">
-						<TextBox.InnerLeftContent>
-							<materialIcons:MaterialIcon
+                        <TextBox.InnerLeftContent>
+                            <materialIcons:MaterialIcon
                                 Grid.Column="0"
                                 Width="24"
                                 Height="24"
                                 Margin="4,0,8,0"
                                 Foreground="{DynamicResource PrimaryHueMidBrush}"
                                 Kind="Forum" />
-						</TextBox.InnerLeftContent>
-						<TextBox.InnerRightContent>
-							<Button
+                        </TextBox.InnerLeftContent>
+                        <TextBox.InnerRightContent>
+                            <Button
                                 Grid.Column="1"
                                 Margin="8,0,0,0"
                                 Padding="4"
                                 Command="{Binding ExportSingleChannelCommand}"
                                 Theme="{DynamicResource MaterialFlatButton}"
                                 ToolTip.Tip="Export Channel by Id">
-								<materialIcons:MaterialIcon
+                                <materialIcons:MaterialIcon
                                     Width="24"
                                     Height="24"
                                     Kind="ArrowRight" />
-							</Button>
-						</TextBox.InnerRightContent>
-					</TextBox>
-				</materialStyles:Card>
-			</Grid>
-				<!--  Progress  -->
+                            </Button>
+                        </TextBox.InnerRightContent>
+                    </TextBox>
+                </materialStyles:Card>
+            </Grid>
+            <!--  Progress  -->
             <ProgressBar
                 Height="4"
                 Background="Transparent"
@@ -313,7 +313,8 @@
                         <LineBreak />
 
                         <Run Text="*  Automating user accounts is technically against TOS —" />
-                        <Run FontWeight="SemiBold" Text="use at your own risk" /><Run Text="!" />
+                        <Run FontWeight="SemiBold" Text="use at your own risk" />
+                        <Run Text="!" />
                         <LineBreak />
 
                         <Run Text="1. Open Discord in your" />

--- a/DiscordChatExporter.Gui/Views/Components/DashboardView.axaml
+++ b/DiscordChatExporter.Gui/Views/Components/DashboardView.axaml
@@ -57,33 +57,33 @@
 
                 <!-- Single Channel Button-->
                 <Button
-					Grid.Column="1"
-					Margin="4,0,0,0"
-					Padding="8"
+                    Grid.Column="1"
+                    Margin="4,0,0,0"
+                    Padding="8"
                     VerticalAlignment="Center"
-					Command="{Binding TogglePullSingleChannelCommand}"
-					IsDefault="True"
-					Theme="{DynamicResource MaterialFlatButton}"
-					IsVisible="{Binding !ShowPullSingleChannel}"
-					ToolTip.Tip="You already have the Channel Id and just want to quickly export it">
+                    Command="{Binding TogglePullSingleChannelCommand}"
+                    IsDefault="True"
+                    Theme="{DynamicResource MaterialFlatButton}"
+                    IsVisible="{Binding !ShowPullSingleChannel}"
+                    ToolTip.Tip="You already have the Channel Id and just want to quickly export it">
                     <materialIcons:MaterialIcon
-						Width="24"
-						Height="24"
-						Kind="LightningBoltOutline" />
+                        Width="24"
+                        Height="24"
+                        Kind="LightningBoltOutline" />
                 </Button>
                 <Button
-					Grid.Column="1"
-					Margin="4,0,0,0"
-					Padding="8"
+                    Grid.Column="1"
+                    Margin="4,0,0,0"
+                    Padding="8"
                     VerticalAlignment="Center"
-					Command="{Binding TogglePullSingleChannelCommand}"
-					Theme="{DynamicResource MaterialFlatButton}"
-					IsVisible="{Binding ShowPullSingleChannel}"
-					ToolTip.Tip="You already have the Channel Id and just want to quickly export it">
+                    Command="{Binding TogglePullSingleChannelCommand}"
+                    Theme="{DynamicResource MaterialFlatButton}"
+                    IsVisible="{Binding ShowPullSingleChannel}"
+                    ToolTip.Tip="You already have the Channel Id and just want to quickly export it">
                     <materialIcons:MaterialIcon
-						Width="24"
-						Height="24"
-						Kind="LightningBolt" />
+                        Width="24"
+                        Height="24"
+                        Kind="LightningBolt" />
                 </Button>
 
                 <!--  Settings button  -->
@@ -107,9 +107,9 @@
 
             <!-- Single Channel Input -->
             <Grid
-				Margin="12,12,8,12"
-				ColumnDefinitions="*,Auto"
-			    IsVisible="{Binding ShowPullSingleChannel}">
+                Margin="12,12,8,12"
+                ColumnDefinitions="*,Auto"
+                IsVisible="{Binding ShowPullSingleChannel}">
                 <materialStyles:Card Grid.Column="0">
                     <!--  Channel Id  -->
                     <TextBox
@@ -155,7 +155,7 @@
         <Panel
             Background="{DynamicResource MaterialCardBackgroundBrush}"
             DockPanel.Dock="Bottom"
-			IsVisible="{Binding !ShowPullSingleChannel}"
+            IsVisible="{Binding !ShowPullSingleChannel}"
             IsEnabled="{Binding !IsBusy}">
             <Panel.Styles>
                 <Style Selector="Panel">

--- a/DiscordChatExporter.Gui/Views/Components/DashboardView.axaml
+++ b/DiscordChatExporter.Gui/Views/Components/DashboardView.axaml
@@ -55,35 +55,19 @@
                     </TextBox>
                 </materialStyles:Card>
 
-                <!-- Single Channel Button-->
+                <!-- Quick Export Button-->
                 <Button
                     Grid.Column="1"
                     Margin="4,0,0,0"
                     Padding="8"
                     VerticalAlignment="Center"
-                    Command="{Binding TogglePullSingleChannelCommand}"
-                    IsDefault="True"
+                    Command="{Binding ShowQuickExportCommand}"
                     Theme="{DynamicResource MaterialFlatButton}"
-                    IsVisible="{Binding !ShowPullSingleChannel}"
-                    ToolTip.Tip="Quick-Export with a given Channel Id">
+                    ToolTip.Tip="Quick-Export with given Channel Ids">
                     <materialIcons:MaterialIcon
                         Width="24"
                         Height="24"
-                        Kind="LightningBoltOutline" />
-                </Button>
-                <Button
-                    Grid.Column="1"
-                    Margin="4,0,0,0"
-                    Padding="8"
-                    VerticalAlignment="Center"
-                    Command="{Binding TogglePullSingleChannelCommand}"
-                    Theme="{DynamicResource MaterialFlatButton}"
-                    IsVisible="{Binding ShowPullSingleChannel}"
-                    ToolTip.Tip="You already have the Channel Id and just want to quickly export it">
-                    <materialIcons:MaterialIcon
-                        Width="24"
-                        Height="24"
-                        Kind="LightningBolt" />
+                        Kind="PoundBoxOutline" />
                 </Button>
 
                 <!--  Settings button  -->
@@ -101,48 +85,8 @@
                         Height="24"
                         Kind="Settings" />
                 </Button>
-
-
             </Grid>
 
-            <!-- Single Channel Input -->
-            <Grid
-                Margin="12,12,8,12"
-                ColumnDefinitions="*,Auto"
-                IsVisible="{Binding ShowPullSingleChannel}">
-                <materialStyles:Card Grid.Column="0">
-                    <!--  Channel Id  -->
-                    <TextBox
-                        FontSize="16"
-                        Text="{Binding ChannelId}"
-                        Theme="{DynamicResource SoloTextBox}"
-                        Watermark="Channel Id">
-                        <TextBox.InnerLeftContent>
-                            <materialIcons:MaterialIcon
-                                Grid.Column="0"
-                                Width="24"
-                                Height="24"
-                                Margin="4,0,8,0"
-                                Foreground="{DynamicResource PrimaryHueMidBrush}"
-                                Kind="Forum" />
-                        </TextBox.InnerLeftContent>
-                        <TextBox.InnerRightContent>
-                            <Button
-                                Grid.Column="1"
-                                Margin="8,0,0,0"
-                                Padding="4"
-                                Command="{Binding ExportSingleChannelCommand}"
-                                Theme="{DynamicResource MaterialFlatButton}"
-                                ToolTip.Tip="Export Channel by Id">
-                                <materialIcons:MaterialIcon
-                                    Width="24"
-                                    Height="24"
-                                    Kind="ArrowRight" />
-                            </Button>
-                        </TextBox.InnerRightContent>
-                    </TextBox>
-                </materialStyles:Card>
-            </Grid>
             <!--  Progress  -->
             <ProgressBar
                 Height="2"

--- a/DiscordChatExporter.Gui/Views/Components/DashboardView.axaml
+++ b/DiscordChatExporter.Gui/Views/Components/DashboardView.axaml
@@ -65,7 +65,7 @@
                     IsDefault="True"
                     Theme="{DynamicResource MaterialFlatButton}"
                     IsVisible="{Binding !ShowPullSingleChannel}"
-                    ToolTip.Tip="You already have the Channel Id and just want to quickly export it">
+                    ToolTip.Tip="Quick-Export with a given Channel Id">
                     <materialIcons:MaterialIcon
                         Width="24"
                         Height="24"

--- a/DiscordChatExporter.Gui/Views/Dialogs/QuickExportView.axaml
+++ b/DiscordChatExporter.Gui/Views/Dialogs/QuickExportView.axaml
@@ -1,0 +1,56 @@
+<UserControl
+    x:Class="DiscordChatExporter.Gui.Views.Dialogs.QuickExportView"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="clr-namespace:DiscordChatExporter.Gui.Converters"
+    xmlns:dialogs="clr-namespace:DiscordChatExporter.Gui.ViewModels.Dialogs"
+    xmlns:materialIcons="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
+    Width="380"
+    x:DataType="dialogs:QuickExportViewModel">
+    <Grid RowDefinitions="Auto,*,Auto">
+        
+        <TextBox
+            x:Name="QueryTextBox"
+            AcceptsReturn="True"
+            FontSize="16"
+            MaxLines="4"
+            ScrollViewer.HorizontalScrollBarVisibility="Hidden"
+            Text="{Binding Query}"
+            Theme="{DynamicResource SoloTextBox}"
+            Watermark="URL or search query">
+            <TextBox.InnerLeftContent>
+                <materialIcons:MaterialIcon
+                    Width="24"
+                    Height="24"
+                    Margin="4,0,8,0"
+                    Kind="Search" />
+            </TextBox.InnerLeftContent>
+            <TextBox.InnerRightContent>
+                <Button
+                    x:Name="ProcessQueryButton"
+                    Margin="8,0,0,0"
+                    Padding="4"
+                    Command="{Binding ProcessQueryCommand}"
+                    IsDefault="True"
+                    Theme="{DynamicResource MaterialFlatButton}"
+                    ToolTip.Tip="Process query (Enter)">
+                    <materialIcons:MaterialIcon
+                        Width="24"
+                        Height="24"
+                        Kind="ArrowRight" />
+                </Button>
+            </TextBox.InnerRightContent>
+        </TextBox>
+
+        <!--  Close button  -->
+        <Button
+            Grid.Row="2"
+            Margin="16"
+            HorizontalAlignment="Stretch"
+            Command="{Binding CloseCommand}"
+            Content="CLOSE"
+            IsCancel="True"
+            IsDefault="True"
+            Theme="{DynamicResource MaterialOutlineButton}" />
+    </Grid>
+</UserControl>

--- a/DiscordChatExporter.Gui/Views/Dialogs/QuickExportView.axaml.cs
+++ b/DiscordChatExporter.Gui/Views/Dialogs/QuickExportView.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace DiscordChatExporter.Gui.Views.Dialogs
+{
+    public partial class QuickExportView : UserControl
+    {
+        public QuickExportView()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
# Reason for PR
Users tend to get frustrated or impatient with the GUI which loads *all* guilds and *all* channels. Especially when including Threads.  
The CLI, which can easily do this selectively, however is way too complicated for laymen who have never seen an open command line. 
Thus, for accessibility reasons, we could allow the quick-export functionality of a given specific channel id via the GUI as well. 

--- 
# Changes:

## New starting view, added the flash button:
![image](https://github.com/Tyrrrz/DiscordChatExporter/assets/54688434/bb88cd23-e163-4ba9-bdd4-8cf5252b970f)

![image](https://github.com/Tyrrrz/DiscordChatExporter/assets/54688434/f5803871-af4b-4f33-954f-17c503974b95)

## The Flash Button toggles a new input, which allows to export a single channel via a given Id:
![image](https://github.com/Tyrrrz/DiscordChatExporter/assets/54688434/361eaf7b-6d63-47ed-a0fb-74a1aad6b654)

## Which functions like hitting Export on a singular channel when going for the elaborate way through the list of all guilds and all channels:
![image](https://github.com/Tyrrrz/DiscordChatExporter/assets/54688434/ee3e5f2d-76d0-4f55-82eb-341d1fa782f5)

