### PR TITLE
Add `%d` template token to CLI docs

### DIFF
--- a/.docs/Using-the-CLI.md
+++ b/.docs/Using-the-CLI.md
@@ -128,6 +128,7 @@ Here is the full list of supported template tokens:
 - `%P` - category position
 - `%a` - the "after" date
 - `%b` - the "before" date
+- `%d` - the current date
 - `%%` - escapes `%`
 
 #### Partitioning


### PR DESCRIPTION
this pull request adds the missing `%d` placeholder to the CLI docs.
the attached picture shows the GUI application suggesting this placeholder is available, and I confirmed it works in the CLI as well.

![image](https://github.com/user-attachments/assets/2219a9cc-b08c-48b8-891d-a8a05cf5969b)
