### PR TITLE
Prefer message timestamp over the `last-modified` header for asset file dates

### DIFF
--- a/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
@@ -49,41 +49,12 @@ internal partial class ExportAssetDownloader(string workingDirPath, bool reuse)
                 await using (var output = File.Create(filePath))
                     await response.Content.CopyToAsync(output, innerCancellationToken);
 
-                // Try to set the file date according to the last-modified header
-                try
+                // Try to set the file date according to the message timestamp
+                if (timestamp is not null)
                 {
-                    if (timestamp is null)
-                    {
-                        var lastModified = response
-                            .Content.Headers.TryGetValue("Last-Modified")
-                            ?.Pipe(s =>
-                                DateTimeOffset.TryParse(
-                                    s,
-                                    CultureInfo.InvariantCulture,
-                                    DateTimeStyles.None,
-                                    out var instant
-                                )
-                                    ? instant
-                                    : (DateTimeOffset?)null
-                            );
-                        if (lastModified is not null)
-                        {
-                            timestamp = lastModified;
-                        }
-                    }
-
-                    if (timestamp is not null)
-                    {
-                        File.SetCreationTimeUtc(filePath, timestamp.Value.UtcDateTime);
-                        File.SetLastWriteTimeUtc(filePath, timestamp.Value.UtcDateTime);
-                        File.SetLastAccessTimeUtc(filePath, timestamp.Value.UtcDateTime);
-                    }
-                }
-                catch
-                {
-                    // This can apparently fail for some reason.
-                    // Updating the file date is not a critical task, so we'll just ignore exceptions thrown here.
-                    // https://github.com/Tyrrrz/DiscordChatExporter/issues/585
+                    File.SetCreationTimeUtc(filePath, timestamp.Value.UtcDateTime);
+                    File.SetLastWriteTimeUtc(filePath, timestamp.Value.UtcDateTime);
+                    File.SetLastAccessTimeUtc(filePath, timestamp.Value.UtcDateTime);
                 }
             },
             cancellationToken

--- a/DiscordChatExporter.Core/Exporting/ExportContext.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportContext.cs
@@ -103,7 +103,8 @@ internal class ExportContext(DiscordClient discord, ExportRequest request)
 
     public async ValueTask<string> ResolveAssetUrlAsync(
         string url,
-        CancellationToken cancellationToken = default
+        CancellationToken cancellationToken = default,
+        DateTimeOffset? timestamp = null
     )
     {
         if (!Request.ShouldDownloadAssets)
@@ -111,7 +112,7 @@ internal class ExportContext(DiscordClient discord, ExportRequest request)
 
         try
         {
-            var filePath = await _assetDownloader.DownloadAsync(url, cancellationToken);
+            var filePath = await _assetDownloader.DownloadAsync(url, cancellationToken, timestamp);
             var relativeFilePath = Path.GetRelativePath(Request.OutputDirPath, filePath);
 
             // Prefer the relative path so that the export package can be copied around without breaking references.

--- a/DiscordChatExporter.Core/Exporting/JsonMessageWriter.cs
+++ b/DiscordChatExporter.Core/Exporting/JsonMessageWriter.cs
@@ -436,7 +436,7 @@ internal class JsonMessageWriter(Stream stream, ExportContext context)
             _writer.WriteString("id", attachment.Id.ToString());
             _writer.WriteString(
                 "url",
-                await Context.ResolveAssetUrlAsync(attachment.Url, cancellationToken)
+                await Context.ResolveAssetUrlAsync(attachment.Url, cancellationToken, message.Timestamp)
             );
             _writer.WriteString("fileName", attachment.FileName);
             _writer.WriteNumber("fileSizeBytes", attachment.FileSize.TotalBytes);
@@ -466,7 +466,7 @@ internal class JsonMessageWriter(Stream stream, ExportContext context)
             _writer.WriteString("format", sticker.Format.ToString());
             _writer.WriteString(
                 "sourceUrl",
-                await Context.ResolveAssetUrlAsync(sticker.SourceUrl, cancellationToken)
+                await Context.ResolveAssetUrlAsync(sticker.SourceUrl, cancellationToken, message.Timestamp)
             );
 
             _writer.WriteEndObject();


### PR DESCRIPTION
Fixes #1320.

With this PR, date-modified timestamp for attachments now prefers the timestamp of the message in which the attachment was originally shared on Discord:

Performing export of the same channel as originally shared in #1320:
```
$ DISCORD_TOKEN="xyz" dotnet run --project DiscordChatExporter.Cli/DiscordChatExporter.Cli.csproj export --channel 869238366951079956 --output . --media --reuse-media --markdown false --format Json --after 1296272363444375632 --before 1312437546873131059

$ stat -c '%y' "Tyrrrz: Open Source - 📦 Projects - youtube-downloader [869238366951079956] (2024-10-17 to 2024-11-30).json_Files"/image*.png
2024-11-01 02:30:27.462000000 +0530
2024-11-17 15:37:14.379000000 +0530
2024-11-01 03:45:28.735000000 +0530
2024-11-01 03:31:24.518000000 +0530
2024-11-22 14:50:38.695000000 +0530
2024-10-29 15:21:46.986000000 +0530
2024-11-01 03:45:28.735000000 +0530
2024-11-03 20:56:30.421000000 +0530
2024-11-01 03:48:04.651000000 +0530
2024-11-01 03:37:37.762000000 +0530
2024-11-01 03:31:24.518000000 +0530
2024-11-01 03:37:37.762000000 +0530
2024-11-01 03:28:05.389000000 +0530
2024-11-01 03:45:28.735000000 +0530
```

Not sure if this is the best approach to implement this, but it seems to work well enough for my current use-case.