### PR TITLE
Don't attempt to infer asset timestamp from message timestamp

### DIFF
--- a/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
@@ -23,8 +22,7 @@ internal partial class ExportAssetDownloader(string workingDirPath, bool reuse)
 
     public async ValueTask<string> DownloadAsync(
         string url,
-        CancellationToken cancellationToken = default,
-        DateTimeOffset? timestamp = null
+        CancellationToken cancellationToken = default
     )
     {
         var fileName = GetFileNameFromUrl(url);
@@ -46,16 +44,8 @@ internal partial class ExportAssetDownloader(string workingDirPath, bool reuse)
             {
                 // Download the file
                 using var response = await Http.Client.GetAsync(url, innerCancellationToken);
-                await using (var output = File.Create(filePath))
-                    await response.Content.CopyToAsync(output, innerCancellationToken);
-
-                // Try to set the file date according to the message timestamp
-                if (timestamp is not null)
-                {
-                    File.SetCreationTimeUtc(filePath, timestamp.Value.UtcDateTime);
-                    File.SetLastWriteTimeUtc(filePath, timestamp.Value.UtcDateTime);
-                    File.SetLastAccessTimeUtc(filePath, timestamp.Value.UtcDateTime);
-                }
+                await using var output = File.Create(filePath);
+                await response.Content.CopyToAsync(output, innerCancellationToken);
             },
             cancellationToken
         );

--- a/DiscordChatExporter.Core/Exporting/ExportContext.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportContext.cs
@@ -106,8 +106,7 @@ internal class ExportContext(DiscordClient discord, ExportRequest request)
 
     public async ValueTask<string> ResolveAssetUrlAsync(
         string url,
-        CancellationToken cancellationToken = default,
-        DateTimeOffset? timestamp = null
+        CancellationToken cancellationToken = default
     )
     {
         if (!Request.ShouldDownloadAssets)
@@ -115,7 +114,7 @@ internal class ExportContext(DiscordClient discord, ExportRequest request)
 
         try
         {
-            var filePath = await _assetDownloader.DownloadAsync(url, cancellationToken, timestamp);
+            var filePath = await _assetDownloader.DownloadAsync(url, cancellationToken);
             var relativeFilePath = Path.GetRelativePath(Request.OutputDirPath, filePath);
 
             // Prefer the relative path so that the export package can be copied around without breaking references.

--- a/DiscordChatExporter.Core/Exporting/JsonMessageWriter.cs
+++ b/DiscordChatExporter.Core/Exporting/JsonMessageWriter.cs
@@ -435,11 +435,7 @@ internal class JsonMessageWriter(Stream stream, ExportContext context)
             _writer.WriteString("id", attachment.Id.ToString());
             _writer.WriteString(
                 "url",
-                await Context.ResolveAssetUrlAsync(
-                    attachment.Url,
-                    cancellationToken,
-                    message.Timestamp
-                )
+                await Context.ResolveAssetUrlAsync(attachment.Url, cancellationToken)
             );
             _writer.WriteString("fileName", attachment.FileName);
             _writer.WriteNumber("fileSizeBytes", attachment.FileSize.TotalBytes);
@@ -469,11 +465,7 @@ internal class JsonMessageWriter(Stream stream, ExportContext context)
             _writer.WriteString("format", sticker.Format.ToString());
             _writer.WriteString(
                 "sourceUrl",
-                await Context.ResolveAssetUrlAsync(
-                    sticker.SourceUrl,
-                    cancellationToken,
-                    message.Timestamp
-                )
+                await Context.ResolveAssetUrlAsync(sticker.SourceUrl, cancellationToken)
             );
 
             _writer.WriteEndObject();


### PR DESCRIPTION
This is inaccurate and somewhat works only for attachments anyway. Not worth the overhead.

Note that DCE is not an image/video/media scrapping tool, it's a chat exporting tool. The downloaded assets are not meant to be used outside of the export, so the file dates are kind of irrelevant.