### PR TITLE
Revert to `Uri.EscapeDataString` when encoding asset URIs

### DIFF
--- a/DiscordChatExporter.Core/Utils/Url.cs
+++ b/DiscordChatExporter.Core/Utils/Url.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+﻿using System;
 using System.Text;
 
 namespace DiscordChatExporter.Core.Utils;
@@ -18,12 +18,12 @@ public static class Url
             var separatorIndex = filePath.IndexOfAny([':', '/', '\\'], position);
             if (separatorIndex < 0)
             {
-                buffer.Append(WebUtility.UrlEncode(filePath[position..]));
+                buffer.Append(Uri.EscapeDataString(filePath[position..]));
                 break;
             }
 
             // Append the segment
-            buffer.Append(WebUtility.UrlEncode(filePath[position..separatorIndex]));
+            buffer.Append(Uri.EscapeDataString(filePath[position..separatorIndex]));
 
             // Append the separator
             buffer.Append(


### PR DESCRIPTION
<!--

**Important**

This pull request should be linked to an issue that describes the problem it addresses.
If there is no corresponding issue yet, please create one first.

An open issue provides a good place to iron out technical requirements and discuss potential solutions.
Creating a pull request without prior discussion may very likely lead to wasted effort.

-->

<!-- Please specify the issue(s) addressed by this pull request: -->

Closes #1353 

<!--

Also keep in mind:

- Pull requests should be as small as possible. Split larger changes into multiple pull requests if needed.
- Follow the coding style and conventions already established in the project. When in doubt, ask in the comments.
- You can add review comments to your own code. Use this to highlight something important or to seek further input from reviewers.

-->

After fixing #1351, a commit was made to change the encoding function from `Uri.EscapeDataString` to `WebUtility.UrlEncode`. This introduced a new bug because the latter function encodes spaces as `+`, which is a valid filename character and not interpreted correctly by the asset links. This PR rolls back the change to restore the intended behavior. I've tested that filenames which include both ` ` and `%` are properly handled.