### PR TITLE
Remove hate

### DIFF
--- a/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
+++ b/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
@@ -131,15 +131,6 @@ public abstract class ExportCommandBase : DiscordCommandBase
     [CommandOption("utc", Description = "Normalize all timestamps to UTC+0.")]
     public bool IsUtcNormalizationEnabled { get; init; } = false;
 
-    [CommandOption(
-        "fuck-russia",
-        EnvironmentVariable = "FUCK_RUSSIA",
-        Description = "Don't print the Support Ukraine message to the console.",
-        // Use a converter to accept '1' as 'true' to reuse the existing environment variable
-        Converter = typeof(TruthyBooleanBindingConverter)
-    )]
-    public bool IsUkraineSupportMessageDisabled { get; init; } = false;
-
     [field: AllowNull, MaybeNull]
     protected ChannelExporter Exporter => field ??= new ChannelExporter(Discord);
 
@@ -352,39 +343,6 @@ public abstract class ExportCommandBase : DiscordCommandBase
 
     public override async ValueTask ExecuteAsync(IConsole console)
     {
-        // Support Ukraine callout
-        if (!IsUkraineSupportMessageDisabled)
-        {
-            console.Output.WriteLine(
-                "┌────────────────────────────────────────────────────────────────────┐"
-            );
-            console.Output.WriteLine(
-                "│   Thank you for supporting Ukraine <3                              │"
-            );
-            console.Output.WriteLine(
-                "│                                                                    │"
-            );
-            console.Output.WriteLine(
-                "│   As Russia wages a genocidal war against my country,              │"
-            );
-            console.Output.WriteLine(
-                "│   I'm grateful to everyone who continues to                        │"
-            );
-            console.Output.WriteLine(
-                "│   stand with Ukraine in our fight for freedom.                     │"
-            );
-            console.Output.WriteLine(
-                "│                                                                    │"
-            );
-            console.Output.WriteLine(
-                "│   Learn more: https://tyrrrz.me/ukraine                            │"
-            );
-            console.Output.WriteLine(
-                "└────────────────────────────────────────────────────────────────────┘"
-            );
-            console.Output.WriteLine("");
-        }
-
         await base.ExecuteAsync(console);
     }
 }

--- a/DiscordChatExporter.Gui/Services/SettingsService.cs
+++ b/DiscordChatExporter.Gui/Services/SettingsService.cs
@@ -18,9 +18,6 @@ public partial class SettingsService()
     )
 {
     [ObservableProperty]
-    public partial bool IsUkraineSupportMessageEnabled { get; set; } = true;
-
-    [ObservableProperty]
     public partial ThemeVariant Theme { get; set; }
 
     [ObservableProperty]

--- a/DiscordChatExporter.Gui/ViewModels/MainViewModel.cs
+++ b/DiscordChatExporter.Gui/ViewModels/MainViewModel.cs
@@ -23,30 +23,6 @@ public partial class MainViewModel(
 
     public DashboardViewModel Dashboard { get; } = viewModelManager.CreateDashboardViewModel();
 
-    private async Task ShowUkraineSupportMessageAsync()
-    {
-        if (!settingsService.IsUkraineSupportMessageEnabled)
-            return;
-
-        var dialog = viewModelManager.CreateMessageBoxViewModel(
-            "Thank you for supporting Ukraine!",
-            """
-            As Russia wages a genocidal war against my country, I'm grateful to everyone who continues to stand with Ukraine in our fight for freedom.
-
-            Click LEARN MORE to find ways that you can help.
-            """,
-            "LEARN MORE",
-            "CLOSE"
-        );
-
-        // Disable this message in the future
-        settingsService.IsUkraineSupportMessageEnabled = false;
-        settingsService.Save();
-
-        if (await dialogManager.ShowDialogAsync(dialog) == true)
-            ProcessEx.StartShellExecute("https://tyrrrz.me/ukraine?source=discordchatexporter");
-    }
-
     private async Task ShowDevelopmentBuildMessageAsync()
     {
         if (!Program.IsDevelopmentBuild)
@@ -106,7 +82,6 @@ public partial class MainViewModel(
     [RelayCommand]
     private async Task InitializeAsync()
     {
-        await ShowUkraineSupportMessageAsync();
         await ShowDevelopmentBuildMessageAsync();
         await CheckForUpdatesAsync();
     }

--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,6 @@
 [![Downloads](https://img.shields.io/github/downloads/Tyrrrz/DiscordChatExporter/total.svg)](https://github.com/Tyrrrz/DiscordChatExporter/releases)
 [![Pulls](https://img.shields.io/docker/pulls/tyrrrz/discordchatexporter)](https://hub.docker.com/r/tyrrrz/discordchatexporter)
 [![Discord](https://img.shields.io/discord/869237470565392384?label=discord)](https://discord.gg/2SUWKFnHSm)
-[![Fuck Russia](https://img.shields.io/badge/fuck-russia-e4181c.svg?labelColor=000000)](https://twitter.com/tyrrrz/status/1495972128977571848)
 
 <table>
     <tr>
@@ -26,17 +25,6 @@ It works with direct messages, group messages, and server channels, and supports
 > ❔ If you have questions or issues, **please refer to the [docs](.docs)**.
 
 > 💬 If you want to chat, **join my [Discord server](https://discord.gg/2SUWKFnHSm)**.
-
-## Terms of use<sup>[[?]](https://github.com/Tyrrrz/.github/blob/master/docs/why-so-political.md)</sup>
-
-By using this project or its source code, for any purpose and in any shape or form, you grant your **implicit agreement** to all the following statements:
-
-- You **condemn Russia and its military aggression against Ukraine**
-- You **recognize that Russia is an occupant that unlawfully invaded a sovereign state**
-- You **support Ukraine's territorial integrity, including its claims over temporarily occupied territories of Crimea and Donbas**
-- You **reject false narratives perpetuated by Russian state propaganda**
-
-To learn more about the war and how you can help, [click here](https://tyrrrz.me/ukraine). Glory to Ukraine! 🇺🇦
 
 ## Download
 


### PR DESCRIPTION
This pull request removes all references to the Ukraine support message and political statements from the project, including functionality, settings, and documentation.

### Removal of Ukraine support message functionality:

* [`DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs`](diffhunk://#diff-e5e920cc229d73be64c80d7b611b73567adb5d949eeef4c6fb511c52ba08e9d2L134-L142): Removed the `IsUkraineSupportMessageDisabled` property and the code that displayed the Ukraine support message in the CLI. [[1]](diffhunk://#diff-e5e920cc229d73be64c80d7b611b73567adb5d949eeef4c6fb511c52ba08e9d2L134-L142) [[2]](diffhunk://#diff-e5e920cc229d73be64c80d7b611b73567adb5d949eeef4c6fb511c52ba08e9d2L355-L387)
* [`DiscordChatExporter.Gui/Services/SettingsService.cs`](diffhunk://#diff-14135253ed95ab738681291c859ff7b0a1551320c716db09bf8936f719d8c69fL20-L22): Removed the `IsUkraineSupportMessageEnabled` property from the GUI settings service.
* [`DiscordChatExporter.Gui/ViewModels/MainViewModel.cs`](diffhunk://#diff-9b9566ce994868123ef2f4288b232ffb1420fdc486934533da1fbf28e5567984L26-L49): Removed the `ShowUkraineSupportMessageAsync` method and its invocation during initialization in the GUI. [[1]](diffhunk://#diff-9b9566ce994868123ef2f4288b232ffb1420fdc486934533da1fbf28e5567984L26-L49) [[2]](diffhunk://#diff-9b9566ce994868123ef2f4288b232ffb1420fdc486934533da1fbf28e5567984L109)

### Removal of political statements from documentation:

* [`Readme.md`](diffhunk://#diff-1550ec65ac92f65817fc28928dfef526912b5f52356ff43651369bae92f56031L11): Removed the "Fuck Russia" badge and the "Terms of use" section, which contained political statements condemning Russia and supporting Ukraine. [[1]](diffhunk://#diff-1550ec65ac92f65817fc28928dfef526912b5f52356ff43651369bae92f56031L11) [[2]](diffhunk://#diff-1550ec65ac92f65817fc28928dfef526912b5f52356ff43651369bae92f56031L30-L40)