### PR TITLE
Add Windows installer for CLI using Inno Setup

### DIFF
--- a/Installer/DiscordChatExporterInstaller.iss
+++ b/Installer/DiscordChatExporterInstaller.iss
@@ -1,0 +1,56 @@
+[Setup]
+AppName=Discord Chat Exporter CLI
+AppVersion=2.50.0
+DefaultDirName={pf}\DiscordChatExporter
+DefaultGroupName=DiscordChatExporter
+OutputBaseFilename=DiscordChatExporterSetup
+Compression=lzma
+SolidCompression=yes
+WizardStyle=modern
+
+[Files]
+Source: "App\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
+
+[Icons]
+Name: "{group}\DiscordChatExporter CLI"; Filename: "{app}\DiscordChatExporter.Cli.exe"
+Name: "{group}\Uninstall DiscordChatExporter"; Filename: "{uninstallexe}"
+
+[Tasks]
+Name: addtopath; Description: "Add DiscordChatExporter to system PATH (recommended for CLI use)"; \
+GroupDescription: "Additional Options:"
+
+[Run]
+Filename: "{app}\DiscordChatExporter.Cli.exe"; Description: "Run DiscordChatExporter"; \
+Flags: postinstall nowait skipifsilent
+
+[Code]
+procedure AddAppToPath();
+var
+  Path: string;
+  NewPath: string;
+begin
+  if RegQueryStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', Path) then
+  begin
+    if Pos(ExpandConstant('{app}'), Path) = 0 then
+    begin
+      NewPath := Path;
+      if (Length(NewPath) > 0) and (NewPath[Length(NewPath)] <> ';') then
+        NewPath := NewPath + ';';
+      NewPath := NewPath + ExpandConstant('{app}');
+      RegWriteStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', NewPath);
+    end;
+  end
+  else
+  begin
+    RegWriteStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', ExpandConstant('{app}'));
+  end;
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if (CurStep = ssPostInstall) and WizardIsTaskSelected('addtopath') then
+  begin
+    AddAppToPath();
+  end;
+end;
+

--- a/Installer/README.md
+++ b/Installer/README.md
@@ -1,0 +1,81 @@
+# 🛠️ DiscordChatExporter - Windows Installer
+
+This folder contains a **ready-to-use Inno Setup script** to build a native `.exe` installer for the **DiscordChatExporter CLI** tool on Windows.
+
+---
+
+## ⚙️ Requirements
+
+- **Windows**
+- [Inno Setup 6.x](https://jrsoftware.org/isdl.php) (Free and lightweight)
+
+---
+
+## 📦 Installer Features
+
+- Installs all required CLI files to `Program Files\DiscordChatExporter`
+- Optionally adds the CLI to your system `PATH`
+- Adds Start Menu shortcuts
+- Automatically runs after install (optional)
+
+---
+
+## 🚀 How to Build the Installer
+
+1. **Install Inno Setup 6** if you haven't already.  
+   ➤ https://jrsoftware.org/isdl.php
+
+2. **Prepare your `App/` folder** next to this script.  
+   This folder must contain all the `.exe`, `.dll`, and related files for the CLI.
+
+   Example:
+```
+
+Installer/
+├── DiscordChatExporterInstaller.iss
+└── App/
+├── DiscordChatExporter.Cli.exe
+├── \*.dll
+└── \*.json
+
+```
+
+3. **Open `DiscordChatExporterInstaller.iss`** in the Inno Setup GUI.
+
+4. Click **Build ➜ Compile** ✅
+
+5. You’ll get an installer like:
+```
+
+Output/DiscordChatExporterSetup.exe
+
+````
+
+---
+
+## 🧪 Testing
+
+- After install, open **CMD** and run:
+```sh
+DiscordChatExporter.Cli.exe
+````
+
+If it runs from any directory → you're golden 🏆
+
+---
+
+## 📝 Notes
+
+* This installer is for **CLI only**, not the GUI version.
+* You can modify the script to include custom icons, silent mode, or GUI launcher.
+* Want to auto-build it with GitHub Actions? Ping the project maintainer 💬
+
+---
+
+**Enjoy the CLI like a boss.**
+
+```
+
+
+
+


### PR DESCRIPTION
- Added 'Installer/' folder with Inno Setup script to generate a Windows installer.
- Includes a detailed README for building the installer manually.
- Installer sets up the CLI in Program Files and adds it to PATH.

<!--

**Important**

This pull request should be linked to an issue that describes the problem it addresses.
If there is no corresponding issue yet, please create one first.

An open issue provides a good place to iron out technical requirements and discuss potential solutions.
Creating a pull request without prior discussion may very likely lead to wasted effort.

-->

<!-- Please specify the issue(s) addressed by this pull request: -->

Closes #ISSUE_NUMBER

<!--

Also keep in mind:

- Pull requests should be as small as possible. Split larger changes into multiple pull requests if needed.
- Follow the coding style and conventions already established in the project. When in doubt, ask in the comments.
- You can add review comments to your own code. Use this to highlight something important or to seek further input from reviewers.

-->
