### PR TITLE
Add flag to enable collisionless media downloads

### DIFF
--- a/DiscordChatExporter.Cli.Tests/Specs/SelfContainedSpecs.cs
+++ b/DiscordChatExporter.Cli.Tests/Specs/SelfContainedSpecs.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using CliFx.Infrastructure;
@@ -29,6 +30,53 @@ public class SelfContainedSpecs
             OutputPath = filePath,
             ShouldDownloadAssets = true,
         }.ExecuteAsync(new FakeConsole());
+
+        // Assert
+        Html.Parse(await File.ReadAllTextAsync(filePath))
+            .QuerySelectorAll("body [src]")
+            .Select(e => e.GetAttribute("src")!)
+            .Select(f => Path.GetFullPath(f, dir.Path))
+            .All(File.Exists)
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public async Task I_can_export_a_channel_and_download_all_referenced_assets_with_nested_paths()
+    {
+        // Arrange
+        using var dir = TempDir.Create();
+        var filePath = Path.Combine(dir.Path, "output.html");
+
+        // Act
+        await new ExportChannelsCommand
+        {
+            Token = Secrets.DiscordToken,
+            ChannelIds = [ChannelIds.SelfContainedTestCases],
+            ExportFormat = ExportFormat.HtmlDark,
+            OutputPath = filePath,
+            ShouldDownloadAssets = true,
+            ShouldUseNestedMediaFilePaths = true,
+        }.ExecuteAsync(new FakeConsole());
+
+        // DEBUG: Print what's in the HTML vs what exists
+        var srcPaths = Html.Parse(await File.ReadAllTextAsync(filePath))
+            .QuerySelectorAll("body [src]")
+            .Select(e => e.GetAttribute("src")!)
+            .ToList();
+
+        Console.WriteLine("=== SRC paths in HTML ===");
+        foreach (var src in srcPaths)
+        {
+            var fullPath = Path.GetFullPath(src, dir.Path);
+            var exists = File.Exists(fullPath);
+            Console.WriteLine($"{(exists ? "✓" : "✗")} {src}");
+            Console.WriteLine($"    Full: {fullPath}");
+        }
+
+        Console.WriteLine("\n=== Files actually on disk ===");
+        foreach (var file in Directory.EnumerateFiles(dir.Path, "*", SearchOption.AllDirectories))
+            Console.WriteLine(file);
 
         // Assert
         Html.Parse(await File.ReadAllTextAsync(filePath))

--- a/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
+++ b/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
@@ -97,16 +97,16 @@ public abstract class ExportCommandBase : DiscordCommandBase
 
     [CommandOption(
         "reuse-media",
-        Description = "Reuse previously downloaded assets to avoid redundant requests."
+        Description = "Reuse previously downloaded assets to avoid redundant requests. "
+            + "Keep --media-nested consistent across runs for best results."
     )]
     public bool ShouldReuseAssets { get; init; } = false;
 
     [CommandOption(
-        "new-media-paths",
-        Description = "Saves media with a new file naming convention to prevent collisions. "
-            + "Duplicate media may be downloaded if consecutive runs use different values for this flag."
+        "media-nested",
+        Description = "Saves assets with a nested file naming convention, creating subdirectories for each distinct asset type."
     )]
-    public bool ShouldUseNewMediaFilePaths { get; init; } = false;
+    public bool ShouldUseNestedMediaFilePaths { get; init; } = false;
 
     [CommandOption(
         "media-dir",
@@ -162,9 +162,9 @@ public abstract class ExportCommandBase : DiscordCommandBase
         }
 
         // New media file path can only be enabled if the download assets option is set
-        if (ShouldUseNewMediaFilePaths && !ShouldDownloadAssets)
+        if (ShouldUseNestedMediaFilePaths && !ShouldDownloadAssets)
         {
-            throw new CommandException("Option --new-media-paths cannot be used without --media.");
+            throw new CommandException("Option --media-nested cannot be used without --media.");
         }
 
         // Assets directory can only be specified if the download assets option is set
@@ -283,7 +283,7 @@ public abstract class ExportCommandBase : DiscordCommandBase
                                         ShouldFormatMarkdown,
                                         ShouldDownloadAssets,
                                         ShouldReuseAssets,
-                                        ShouldUseNewMediaFilePaths,
+                                        ShouldUseNestedMediaFilePaths,
                                         Locale,
                                         IsUtcNormalizationEnabled
                                     );

--- a/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
+++ b/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
@@ -102,6 +102,13 @@ public abstract class ExportCommandBase : DiscordCommandBase
     public bool ShouldReuseAssets { get; init; } = false;
 
     [CommandOption(
+        "new-media-paths",
+        Description = "Saves media with a new file naming convention to prevent collisions. "
+            + "Duplicate media may be downloaded if consecutive runs use different values for this flag."
+    )]
+    public bool ShouldUseNewMediaFilePaths { get; init; } = false;
+
+    [CommandOption(
         "media-dir",
         Description = "Download assets to this directory. "
             + "If not specified, the asset directory path will be derived from the output path."
@@ -152,6 +159,12 @@ public abstract class ExportCommandBase : DiscordCommandBase
         if (ShouldReuseAssets && !ShouldDownloadAssets)
         {
             throw new CommandException("Option --reuse-media cannot be used without --media.");
+        }
+
+        // New media file path can only be enabled if the download assets option is set
+        if (ShouldUseNewMediaFilePaths && !ShouldDownloadAssets)
+        {
+            throw new CommandException("Option --new-media-paths cannot be used without --media.");
         }
 
         // Assets directory can only be specified if the download assets option is set
@@ -270,6 +283,7 @@ public abstract class ExportCommandBase : DiscordCommandBase
                                         ShouldFormatMarkdown,
                                         ShouldDownloadAssets,
                                         ShouldReuseAssets,
+                                        ShouldUseNewMediaFilePaths,
                                         Locale,
                                         IsUtcNormalizationEnabled
                                     );

--- a/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
@@ -128,7 +128,7 @@ internal partial class ExportAssetDownloader
             "_",
             query
                 .AllKeys.Where(key => !string.IsNullOrEmpty(key))
-                .Select(key => string.IsNullOrEmpty(query[key]) ? key : $"{key}={query[key]}")
+                .Select(key => string.IsNullOrEmpty(query[key]) ? key : $"{key}-{query[key]}")
         );
     }
 

--- a/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
@@ -16,7 +16,7 @@ namespace DiscordChatExporter.Core.Exporting;
 internal partial class ExportAssetDownloader(
     string workingDirPath,
     bool reuse,
-    bool useNewMediaFilePaths
+    bool useNestedMediaFilePaths
 )
 {
     private static readonly AsyncKeyedLocker<string> Locker = new();
@@ -29,7 +29,7 @@ internal partial class ExportAssetDownloader(
         CancellationToken cancellationToken = default
     )
     {
-        var localFilePath = useNewMediaFilePaths
+        var localFilePath = useNestedMediaFilePaths
             ? GetFilePathFromUrl(url)
             : GetFileNameFromUrlLegacy(url);
         var filePath = Path.Combine(workingDirPath, localFilePath);
@@ -77,7 +77,6 @@ internal partial class ExportAssetDownloader
         // If this isn't a Discord CDN URL, save the file to the `media/external` folder.
         if (!string.Equals(uri.Host, "cdn.discordapp.com", StringComparison.OrdinalIgnoreCase))
         {
-            File.AppendAllTextAsync("external_urls.txt", $"{url}\n");
             return $"external/{uri.Host}{uri.AbsolutePath}";
         }
 

--- a/DiscordChatExporter.Core/Exporting/ExportContext.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportContext.cs
@@ -22,7 +22,7 @@ internal class ExportContext(DiscordClient discord, ExportRequest request)
     private readonly ExportAssetDownloader _assetDownloader = new(
         request.AssetsDirPath,
         request.ShouldReuseAssets,
-        request.ShouldUseNewMediaFilePaths
+        request.ShouldUseNestedMediaFilePaths
     );
 
     public DiscordClient Discord { get; } = discord;

--- a/DiscordChatExporter.Core/Exporting/ExportContext.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportContext.cs
@@ -21,7 +21,8 @@ internal class ExportContext(DiscordClient discord, ExportRequest request)
 
     private readonly ExportAssetDownloader _assetDownloader = new(
         request.AssetsDirPath,
-        request.ShouldReuseAssets
+        request.ShouldReuseAssets,
+        request.ShouldUseNewMediaFilePaths
     );
 
     public DiscordClient Discord { get; } = discord;

--- a/DiscordChatExporter.Core/Exporting/ExportRequest.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportRequest.cs
@@ -39,7 +39,7 @@ public partial class ExportRequest
 
     public bool ShouldReuseAssets { get; }
 
-    public bool ShouldUseNewMediaFilePaths { get; }
+    public bool ShouldUseNestedMediaFilePaths { get; }
 
     public string? Locale { get; }
 
@@ -60,7 +60,7 @@ public partial class ExportRequest
         bool shouldFormatMarkdown,
         bool shouldDownloadAssets,
         bool shouldReuseAssets,
-        bool shouldUseNewMediaFilePaths,
+        bool shouldUseNestedMediaFilePaths,
         string? locale,
         bool isUtcNormalizationEnabled
     )
@@ -75,7 +75,7 @@ public partial class ExportRequest
         ShouldFormatMarkdown = shouldFormatMarkdown;
         ShouldDownloadAssets = shouldDownloadAssets;
         ShouldReuseAssets = shouldReuseAssets;
-        ShouldUseNewMediaFilePaths = shouldUseNewMediaFilePaths;
+        ShouldUseNestedMediaFilePaths = shouldUseNestedMediaFilePaths;
         Locale = locale;
         IsUtcNormalizationEnabled = isUtcNormalizationEnabled;
 

--- a/DiscordChatExporter.Core/Exporting/ExportRequest.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportRequest.cs
@@ -39,6 +39,8 @@ public partial class ExportRequest
 
     public bool ShouldReuseAssets { get; }
 
+    public bool ShouldUseNewMediaFilePaths { get; }
+
     public string? Locale { get; }
 
     public CultureInfo? CultureInfo { get; }
@@ -58,6 +60,7 @@ public partial class ExportRequest
         bool shouldFormatMarkdown,
         bool shouldDownloadAssets,
         bool shouldReuseAssets,
+        bool shouldUseNewMediaFilePaths,
         string? locale,
         bool isUtcNormalizationEnabled
     )
@@ -72,6 +75,7 @@ public partial class ExportRequest
         ShouldFormatMarkdown = shouldFormatMarkdown;
         ShouldDownloadAssets = shouldDownloadAssets;
         ShouldReuseAssets = shouldReuseAssets;
+        ShouldUseNewMediaFilePaths = shouldUseNewMediaFilePaths;
         Locale = locale;
         IsUtcNormalizationEnabled = isUtcNormalizationEnabled;
 

--- a/DiscordChatExporter.Gui/Services/SettingsService.cs
+++ b/DiscordChatExporter.Gui/Services/SettingsService.cs
@@ -67,7 +67,7 @@ public partial class SettingsService()
     public partial bool LastShouldReuseAssets { get; set; }
 
     [ObservableProperty]
-    public partial bool LastShouldUseNewMediaFilePaths { get; set; }
+    public partial bool LastShouldUseNestedMediaFilePaths { get; set; }
 
     [ObservableProperty]
     public partial string? LastAssetsDirPath { get; set; }

--- a/DiscordChatExporter.Gui/Services/SettingsService.cs
+++ b/DiscordChatExporter.Gui/Services/SettingsService.cs
@@ -67,6 +67,9 @@ public partial class SettingsService()
     public partial bool LastShouldReuseAssets { get; set; }
 
     [ObservableProperty]
+    public partial bool LastShouldUseNewMediaFilePaths { get; set; }
+
+    [ObservableProperty]
     public partial string? LastAssetsDirPath { get; set; }
 
     public override void Save()

--- a/DiscordChatExporter.Gui/ViewModels/Components/DashboardViewModel.cs
+++ b/DiscordChatExporter.Gui/ViewModels/Components/DashboardViewModel.cs
@@ -276,7 +276,7 @@ public partial class DashboardViewModel : ViewModelBase
                             dialog.ShouldFormatMarkdown,
                             dialog.ShouldDownloadAssets,
                             dialog.ShouldReuseAssets,
-                            dialog.ShouldUseNewMediaFilePaths,
+                            dialog.ShouldUseNestedMediaFilePaths,
                             _settingsService.Locale,
                             _settingsService.IsUtcNormalizationEnabled
                         );

--- a/DiscordChatExporter.Gui/ViewModels/Components/DashboardViewModel.cs
+++ b/DiscordChatExporter.Gui/ViewModels/Components/DashboardViewModel.cs
@@ -276,6 +276,7 @@ public partial class DashboardViewModel : ViewModelBase
                             dialog.ShouldFormatMarkdown,
                             dialog.ShouldDownloadAssets,
                             dialog.ShouldReuseAssets,
+                            dialog.ShouldUseNewMediaFilePaths,
                             _settingsService.Locale,
                             _settingsService.IsUtcNormalizationEnabled
                         );

--- a/DiscordChatExporter.Gui/ViewModels/Dialogs/ExportSetupViewModel.cs
+++ b/DiscordChatExporter.Gui/ViewModels/Dialogs/ExportSetupViewModel.cs
@@ -68,6 +68,9 @@ public partial class ExportSetupViewModel(
     public partial bool ShouldReuseAssets { get; set; }
 
     [ObservableProperty]
+    public partial bool ShouldUseNewMediaFilePaths { get; set; }
+
+    [ObservableProperty]
     public partial string? AssetsDirPath { get; set; }
 
     [ObservableProperty]
@@ -105,6 +108,7 @@ public partial class ExportSetupViewModel(
         ShouldFormatMarkdown = settingsService.LastShouldFormatMarkdown;
         ShouldDownloadAssets = settingsService.LastShouldDownloadAssets;
         ShouldReuseAssets = settingsService.LastShouldReuseAssets;
+        ShouldUseNewMediaFilePaths = settingsService.LastShouldUseNewMediaFilePaths;
         AssetsDirPath = settingsService.LastAssetsDirPath;
 
         // Show the "advanced options" section by default if any
@@ -183,6 +187,7 @@ public partial class ExportSetupViewModel(
         settingsService.LastShouldFormatMarkdown = ShouldFormatMarkdown;
         settingsService.LastShouldDownloadAssets = ShouldDownloadAssets;
         settingsService.LastShouldReuseAssets = ShouldReuseAssets;
+        settingsService.LastShouldUseNewMediaFilePaths = ShouldUseNewMediaFilePaths;
         settingsService.LastAssetsDirPath = AssetsDirPath;
 
         Close(true);

--- a/DiscordChatExporter.Gui/ViewModels/Dialogs/ExportSetupViewModel.cs
+++ b/DiscordChatExporter.Gui/ViewModels/Dialogs/ExportSetupViewModel.cs
@@ -68,7 +68,7 @@ public partial class ExportSetupViewModel(
     public partial bool ShouldReuseAssets { get; set; }
 
     [ObservableProperty]
-    public partial bool ShouldUseNewMediaFilePaths { get; set; }
+    public partial bool ShouldUseNestedMediaFilePaths { get; set; }
 
     [ObservableProperty]
     public partial string? AssetsDirPath { get; set; }
@@ -108,7 +108,7 @@ public partial class ExportSetupViewModel(
         ShouldFormatMarkdown = settingsService.LastShouldFormatMarkdown;
         ShouldDownloadAssets = settingsService.LastShouldDownloadAssets;
         ShouldReuseAssets = settingsService.LastShouldReuseAssets;
-        ShouldUseNewMediaFilePaths = settingsService.LastShouldUseNewMediaFilePaths;
+        ShouldUseNestedMediaFilePaths = settingsService.LastShouldUseNestedMediaFilePaths;
         AssetsDirPath = settingsService.LastAssetsDirPath;
 
         // Show the "advanced options" section by default if any
@@ -187,7 +187,7 @@ public partial class ExportSetupViewModel(
         settingsService.LastShouldFormatMarkdown = ShouldFormatMarkdown;
         settingsService.LastShouldDownloadAssets = ShouldDownloadAssets;
         settingsService.LastShouldReuseAssets = ShouldReuseAssets;
-        settingsService.LastShouldUseNewMediaFilePaths = ShouldUseNewMediaFilePaths;
+        settingsService.LastShouldUseNestedMediaFilePaths = ShouldUseNestedMediaFilePaths;
         settingsService.LastAssetsDirPath = AssetsDirPath;
 
         Close(true);

--- a/DiscordChatExporter.Gui/Views/Dialogs/ExportSetupView.axaml
+++ b/DiscordChatExporter.Gui/Views/Dialogs/ExportSetupView.axaml
@@ -280,8 +280,8 @@
                             IsEnabled="{Binding ShouldDownloadAssets}"
                             LastChildFill="False"
                             ToolTip.Tip="Uses a new organization to save media files to avoid data loss. If you change this setting from run to run, duplicate media may be downloaded.">
-                            <TextBlock DockPanel.Dock="Left" Text="Use new media file paths" />
-                            <ToggleSwitch DockPanel.Dock="Right" IsChecked="{Binding ShouldUseNewMediaFilePaths}" />
+                            <TextBlock DockPanel.Dock="Left" Text="Use nested media file paths" />
+                            <ToggleSwitch DockPanel.Dock="Right" IsChecked="{Binding ShouldUseNestedMediaFilePaths}" />
                         </DockPanel>
 
                         <!--  Assets path  -->

--- a/DiscordChatExporter.Gui/Views/Dialogs/ExportSetupView.axaml
+++ b/DiscordChatExporter.Gui/Views/Dialogs/ExportSetupView.axaml
@@ -274,6 +274,16 @@
                             <ToggleSwitch DockPanel.Dock="Right" IsChecked="{Binding ShouldReuseAssets}" />
                         </DockPanel>
 
+                        <!--  Use new media file paths  -->
+                        <DockPanel
+                            Margin="16,8"
+                            IsEnabled="{Binding ShouldDownloadAssets}"
+                            LastChildFill="False"
+                            ToolTip.Tip="Uses a new organization to save media files to avoid data loss. If you change this setting from run to run, duplicate media may be downloaded.">
+                            <TextBlock DockPanel.Dock="Left" Text="Use new media file paths" />
+                            <ToggleSwitch DockPanel.Dock="Right" IsChecked="{Binding ShouldUseNewMediaFilePaths}" />
+                        </DockPanel>
+
                         <!--  Assets path  -->
                         <TextBox
                             Margin="16,8"


### PR DESCRIPTION
Closes https://github.com/Tyrrrz/DiscordChatExporter/issues/1231

> [!NOTE]
> My understanding of the original issue is that when downloading media with the `--media` flag (with or without `--reuse-media`) there is a significant chance that multiple pieces of media could attempt to use the same filename + hash, causing all but one media download to be silently lost. If this is wrong, let me know!

## Change proposed 

This PR introduces a new system for saving media downloads gated behind an opt-in flag `--new-media-paths` that eliminates the chance for media filenames to collide by using existing unique IDs from Discord.

## Rationale

This implementation takes inspiration from this PR https://github.com/Tyrrrz/DiscordChatExporter/pull/1232 and its comment https://github.com/Tyrrrz/DiscordChatExporter/issues/1231#issuecomment-2106399351:

> An alternative suggestion to lengthening the hash would be to just put the attachment ID in the filename. I feel like at a certain point, a bunch of random base-32 characters doesn't really provide much utility over 19 digits (which would be guaranteed to never collide).

This seemed reasonable to me, so I decided to look in to implementing a version of it myself for personal use.

The interesting thing I noticed is that out of the 5 Discord media types that DCE downloads via `ExportAssetDownloader` (emojis, stickers, avatars, attachments, server icons), **only three of them use snowflakes** while the other two use hashes. The two that use hashes, avatars and server icons, are uniquely identified by a combination of the member/server ID and the file hash:

| Asset | URL | Unique identifier |
| :--- | :--- | :--- |
| Custom Emoji | `emojis/{emoji_id}.png` | `{emoji_id}` |
| Sticker | `stickers/{sticker_id}.png` | `{sticker_id}` |
| Attachment | `attachments/{channel_id}/{attachment_id}/{attachment}.png` | `{attachment_id}` |
| Guild Icon | `icons/{guild_id}/{guild_icon}.png` | `{guild_id}`+`{guild_icon}` |
| Guild Member Avatar | `guilds/{guild_id}/users/{user_id}/avatars/{member_avatar}.png` | `{user_id}`+`{member_avatar}` |


So strictly speaking, if we wanted to save something using just its unique ID (snowflake or composite ID+hash), we'd have to introspect the URL, determine the type of asset we're downloading, then branch on that to properly extract the right components from the URL.

But we could take this one step further: why extract parts from the URL to construct a unique filename when the URL is already a unique identifier itself? Using the URL itself has the added benefit of naturally separating the media downloads by their type:
emojis go in the `emojis/` folder, stickers go in the `stickers/` folder, etc.

## Single-file examples

When `ExportAssetDownloader` receives a media URL, it checks if the URL is from the Discord CDN. If so, it parses the path from the rest of the URL and uses that as the path to the file that will be saved to disk. 

If the `size` query param is present, that is added as the last folder in the file path (a la Adobe Illustrator's technique for organizing exports of assets across multiple size). This prevents a possible issue where `ExportAssetDownloader` receives two requests for the same asset at different sizes causing one size to be overwritten.

### Discord CDN file
For example, if we get this URL passed: 
```
https://cdn.discordapp.com/emojis/754441880066064584.webp?size=128
```

Then we will save that media to this path on disk
```
{media_path}/emojis/128px/754441880066064584.webp
```

### External media file

If the URL is not from the discord CDN, then it's sequestered into an `external/` subfolder and then uses the path in the URL as the filepath beyond that. For example, an embed might have a URL like the following:
```
https://images-ext-1.discordapp.net/external/kJEb3-XApHsU0ov41y9Nk8BuseDcmeUSHQEtN0swR2M/https/i.ytimg.com/vi/6RghYTEwbpM/maxresdefault.jpg
```

Which would get saved to this location:
```
{media_path}/external/images-ext-1.discordapp.net/external/kJEb3-XApHsU0ov41y9Nk8BuseDcmeUSHQEtN0swR2M/https/i.ytimg.com/vi/6RghYTEwbpM/maxresdefault.jpg
```

## Wholistic directory structure

In effect, running a command that looks something like this:
```sh
./DiscordChatExporter.Cli export
  -t "wHid.spr.bNa" 
  --media 
  --reuse-media 
  --new-media-paths 
  -o "output/data/"
  --media-dir "output/media/"
```

Would result in an output structure along these lines:
```
output/
  data/
    guild name - category - channel1 [id].json
    guild name - category - channel2 [id].json
    guild name - category - channel3 [id].json
    ...
  media/
    attachments/
      173123.../ (server_id)
        145699.../ (attachment_id)
          IMG_1550.png
        ...
      ...
    avatars/
      17294.../ (user id)
        cadcc293.png (avatar hash)
      ...
    emojis/
      1234219.png (emoji id)
      ...
    external/
      cdn.jsdelivr.net/
      images-ext-1.discordapp.net/
      www.youtube.com/
      ...
    guilds/
      170123.../ (guild_id)
        users/
          17290.../ (user id)
            avatars/
              512px/
                50e477.png (avatar hash)
              ...
          ...
      ...
    icons/
      170123.../ (guild_id)
        512px/
          abde23.gif (file hash)
        ...
```

## Comparison to the old behavior

The old behavior puts all media files flat into the same folder. Some benefits of this is that it reduces the number of folders on your disk, reduces the number of characters needed to point to each file, and in a way feels clean when you see everything packaged together. A commonly cited drawback of this is that filename collisions are highly likely.

The new behavior's nesting improves accessibility of casually inspecting the results of a backup via the native file browser. Additionally, the structure allows for external tooling to understand the type of each file, making it easier for other programs to display the downloaded assets (e.g. a simple sticker browser). Finally, filename collisions can never happen with this system while still being idempotent.

A drawback of the new system is that some of the resulting file paths are pretty ugly. If this is a major concern (which would be fairly reasonable as the file paths are essentially the implied public API of `--media`), we could bring back some amount of URL introspection to make them more pretty (e.g. moving server-specific user avatars from `guilds/{guild_id}/users/{user_id}/avatars/{avatar_hash}.png` to `avatars/{user_id}/guilds/{guild_id}/{avatar_hash}.png`.

## Further follow-ups

If this style of change is wanted as a way to fix https://github.com/Tyrrrz/DiscordChatExporter/issues/1231 _before_ v3, then I'm happy to iterate on this PR to make it production-ready. I'd imagine the following changes could be discussed before merging:
- Custom handling of twemoji links (e.g. `https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/svg/1f44d.svg`) to shorten the output file path (for example, to put them in a `twemojis/` folder)
- Custom handling of `images-ext-1.discordapp.net` links to shorten the output file path to just the external URL
- Better sanitation of external media URLs
  - I didn't see any invalid file paths in my testing, but I wonder if it could happen

If this isn't the direction that DCE wants to go in, then I'm happy to keep it in my personal fork. Thanks!