### PR TITLE
Add `x-super-properties` header for user accounts

### DIFF
--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -37,7 +37,8 @@ public class DiscordClient(
             {
                 using var request = new HttpRequestMessage(HttpMethod.Get, new Uri(_baseUri, url));
 
-                // Authorization header
+                // Don't validate because the token can have special characters
+                // https://github.com/Tyrrrz/DiscordChatExporter/issues/828
                 request.Headers.TryAddWithoutValidation(
                     "Authorization",
                     tokenKind == TokenKind.Bot ? $"Bot {token}" : token

--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -103,8 +103,8 @@ public class DiscordClient(
                         _cachedBrowserHeaders = headers;
                     }
 
-                    foreach (var kv in cachedHeaders)
-                        request.Headers.TryAddWithoutValidation(kv.Key, kv.Value);
+                    foreach (var kv in _cachedBrowserHeaders)
+                         if (!request.Headers.Contains(kv.Key)) request.Headers.TryAddWithoutValidation(kv.Key, kv.Value);
                 }
                 catch { }
             }

--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -18,30 +18,6 @@ using JsonExtensions.Reading;
 
 namespace DiscordChatExporter.Core.Discord;
 
-// https://docs.discord.food/reference#launch-signature
-static string GenerateLaunchSignature()
-{
-    const string maskBinary =
-        "00000000100000000001000000010000000010000001000000001000000000000010000010000001000000000100000000000001000000000000100000000000";
-
-    var mask = Convert.ToUInt128(maskBinary, 2);
-
-    var uuid = Guid.NewGuid().ToByteArray();
-    var value = new UInt128(BitConverter.ToUInt64(uuid, 8), BitConverter.ToUInt64(uuid, 0));
-
-    value &= ~mask;
-
-    Span<byte> bytes = stackalloc byte[16];
-    BitConverter.TryWriteBytes(bytes[..8], (ulong)value.Lower);
-    BitConverter.TryWriteBytes(bytes[8..], (ulong)value.Upper);
-
-    return new Guid(bytes).ToString();
-}
-
-static string GenerateUuid()
-{
-    return Guid.NewGuid().ToString();
-}
 
 public class DiscordClient(
     string token,
@@ -50,6 +26,7 @@ public class DiscordClient(
 {
     private readonly Uri _baseUri = new("https://discord.com/api/v10/", UriKind.Absolute);
     private TokenKind? _resolvedTokenKind;
+    private static Dictionary<string, string>? _cachedBrowserHeaders;
 
     private async ValueTask<HttpResponseMessage> GetResponseAsync(
         string url,
@@ -76,9 +53,8 @@ public class DiscordClient(
                 try
                 {
                     // Cache headers from the external API so we don't make this request on every call.
-                    static Dictionary<string, string>? cachedHeaders;
 
-                    if (cachedHeaders is null)
+                    if (_cachedBrowserHeaders is null)
                     {
                         using var apiReq = new HttpRequestMessage(
                             HttpMethod.Post,
@@ -124,7 +100,7 @@ public class DiscordClient(
                             ["x-super-properties"] = xspBase64,
                         };
 
-                        cachedHeaders = headers;
+                        _cachedBrowserHeaders = headers;
                     }
 
                     foreach (var kv in cachedHeaders)

--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -50,7 +50,7 @@ public class DiscordClient(
             // discord flags requests that don't look like a real browser
             if (tokenKind != TokenKind.Bot)
             {
-                try
+                await Task.Run(async () =>
                 {
                     // Cache headers from the external API so we don't make this request on every call.
 
@@ -105,8 +105,7 @@ public class DiscordClient(
 
                     foreach (var kv in _cachedBrowserHeaders)
                          if (!request.Headers.Contains(kv.Key)) request.Headers.TryAddWithoutValidation(kv.Key, kv.Value);
-                }
-                catch { }
+                })
             }
 
                 var response = await Http.Client.SendAsync(

--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -18,6 +18,31 @@ using JsonExtensions.Reading;
 
 namespace DiscordChatExporter.Core.Discord;
 
+// https://docs.discord.food/reference#launch-signature
+static string GenerateLaunchSignature()
+{
+    const string maskBinary =
+        "00000000100000000001000000010000000010000001000000001000000000000010000010000001000000000100000000000001000000000000100000000000";
+
+    var mask = Convert.ToUInt128(maskBinary, 2);
+
+    var uuid = Guid.NewGuid().ToByteArray();
+    var value = new UInt128(BitConverter.ToUInt64(uuid, 8), BitConverter.ToUInt64(uuid, 0));
+
+    value &= ~mask;
+
+    Span<byte> bytes = stackalloc byte[16];
+    BitConverter.TryWriteBytes(bytes[..8], (ulong)value.Lower);
+    BitConverter.TryWriteBytes(bytes[8..], (ulong)value.Upper);
+
+    return new Guid(bytes).ToString();
+}
+
+static string GenerateUuid()
+{
+    return Guid.NewGuid().ToString();
+}
+
 public class DiscordClient(
     string token,
     RateLimitPreference rateLimitPreference = RateLimitPreference.RespectAll
@@ -33,7 +58,7 @@ public class DiscordClient(
     )
     {
         return await Http.ResponseResiliencePipeline.ExecuteAsync(
-           async innerCancellationToken =>
+            async innerCancellationToken =>
             {
                 using var request = new HttpRequestMessage(HttpMethod.Get, new Uri(_baseUri, url));
 
@@ -55,19 +80,33 @@ public class DiscordClient(
                             innerCancellationToken
                         );
 
-                        var userHeaders = JsonSerializer.Deserialize<Dictionary<string, string>>(headersJson);
-                        if (userHeaders is not null)
+                        var userHeaders = JsonSerializer.Deserialize<Dictionary<string, string>>(
+                            headersJson
+                        );
+
+                        if (userHeaders.TryGetValue("x-super-properties", out var xsp))
                         {
+                            var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(xsp));
+
+                            var props = JsonSerializer.Deserialize<Dictionary<string, object>>(
+                                decoded
+                            );
+
+                            props["client_heartbeat_session_id"] = GenerateUuid();
+                            props["client_launch_id"] = GenerateUuid();
+                            props["client_launch_signature"] = GenerateLaunchSignature();
+
+                            var newJson = JsonSerializer.Serialize(props);
+                            var newBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(newJson));
+
+                            userHeaders["x-super-properties"] = newBase64;
+
                             foreach (var kv in userHeaders)
                                 request.Headers.TryAddWithoutValidation(kv.Key, kv.Value);
                         }
                     }
-                    catch
-                    {
-
-                    }
+                    catch { }
                 }
-
 
                 var response = await Http.Client.SendAsync(
                     request,

--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -70,40 +70,86 @@ public class DiscordClient(
                 );
 
                 // add browser headers like x-super-properties and user-agent
-                // this is really important as discord flags requests that dont have valid xsp header
+                // discord flags requests that don't look like a real browser
                 if (tokenKind != TokenKind.Bot)
                 {
                     try
                     {
-                        var headersJson = await Http.Client.GetStringAsync(
-                            "https://gist.githubusercontent.com/MinerPL/731977099ca84bef7ad0a66978010045/raw/stable.headers.json",
+                        var apiJson = await Http.Client.GetStringAsync(
+                            "https://cordapi.dolfi.es/api/v2/properties/web",
                             innerCancellationToken
                         );
 
-                        var userHeaders = JsonSerializer.Deserialize<Dictionary<string, string>>(
-                            headersJson
-                        );
+                        using var doc = JsonDocument.Parse(apiJson);
 
-                        if (userHeaders.TryGetValue("x-super-properties", out var xsp))
+                        var client = doc.RootElement.GetProperty("client");
+                        var browser = doc.RootElement.GetProperty("browser");
+                        var os = browser.GetProperty("os");
+
+                        string userAgent = browser.GetProperty("user_agent").GetString()!;
+                        string browserVersion = browser.GetProperty("version").GetString()!;
+                        string browserType = browser.GetProperty("type").GetString()!;
+                        string osType = os.GetProperty("type").GetString()!;
+                        string osVersion = os.GetProperty("version").GetString()!;
+
+                        int buildNumber = client.GetProperty("build_number").GetInt32();
+                        string releaseChannel = client.GetProperty("release_channel").GetString()!;
+
+                        string chromeMajor = browserVersion.Split('.')[0];
+
+                        var xsp = new Dictionary<string, object?>
                         {
-                            var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(xsp));
+                            ["os"] = osType,
+                            ["browser"] = browserType,
+                            ["device"] = "",
+                            ["system_locale"] = "en-US",
 
-                            var props = JsonSerializer.Deserialize<Dictionary<string, object>>(
-                                decoded
-                            );
+                            ["browser_user_agent"] = userAgent,
+                            ["browser_version"] = browserVersion,
+                            ["os_version"] = osVersion,
 
-                            props["client_heartbeat_session_id"] = GenerateUuid();
-                            props["client_launch_id"] = GenerateUuid();
-                            props["client_launch_signature"] = GenerateLaunchSignature();
+                            ["referrer"] = "",
+                            ["referring_domain"] = "",
+                            ["referrer_current"] = "https://www.google.com/",
+                            ["referring_domain_current"] = "www.google.com",
+                            ["search_engine_current"] = "google",
+                            ["mp_keyword_current"] = "discord",
 
-                            var newJson = JsonSerializer.Serialize(props);
-                            var newBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(newJson));
+                            ["release_channel"] = releaseChannel,
+                            ["client_build_number"] = buildNumber,
+                            ["client_event_source"] = null,
+                            ["has_client_mods"] = false,
 
-                            userHeaders["x-super-properties"] = newBase64;
+                            ["client_launch_id"] = GenerateUuid(),
+                            ["launch_signature"] = GenerateLaunchSignature(),
+                            ["client_heartbeat_session_id"] = GenerateUuid(),
+                        };
 
-                            foreach (var kv in userHeaders)
-                                request.Headers.TryAddWithoutValidation(kv.Key, kv.Value);
-                        }
+                        var xspJson = JsonSerializer.Serialize(xsp);
+                        var xspBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(xspJson));
+
+                        var headers = new Dictionary<string, string>
+                        {
+                            ["sec-ch-ua-platform"] = $"\"{osType}\"",
+                            ["referer"] = "https://discord.com/app",
+                            ["x-debug-options"] = "bugReporterEnabled",
+                            ["accept-language"] = "en-US,en;q=0.9",
+
+                            ["sec-ch-ua"] =
+                                $"\"Chromium\";v=\"{chromeMajor}\", \"Not;A=Brand\";v=\"99\"",
+
+                            ["sec-ch-ua-mobile"] = "?0",
+
+                            ["x-discord-timezone"] = "Europe/Warsaw",
+                            ["x-context-properties"] = "eyJsb2NhdGlvbiI6Ii9hcHAifQ==",
+                            ["x-discord-locale"] = "en-US",
+
+                            ["user-agent"] = userAgent,
+                            ["x-super-properties"] = xspBase64,
+                        };
+
+                        foreach (var kv in headers)
+                            request.Headers.TryAddWithoutValidation(kv.Key, kv.Value);
                     }
                     catch { }
                 }

--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -33,16 +33,40 @@ public class DiscordClient(
     )
     {
         return await Http.ResponseResiliencePipeline.ExecuteAsync(
-            async innerCancellationToken =>
+           async innerCancellationToken =>
             {
                 using var request = new HttpRequestMessage(HttpMethod.Get, new Uri(_baseUri, url));
 
-                // Don't validate because the token can have special characters
-                // https://github.com/Tyrrrz/DiscordChatExporter/issues/828
+                // Authorization header
                 request.Headers.TryAddWithoutValidation(
                     "Authorization",
                     tokenKind == TokenKind.Bot ? $"Bot {token}" : token
                 );
+
+                // add browser headers like x-super-properties and user-agent
+                // this is really important as discord flags requests that dont have valid xsp header
+                if (tokenKind != TokenKind.Bot)
+                {
+                    try
+                    {
+                        var headersJson = await Http.Client.GetStringAsync(
+                            "https://gist.githubusercontent.com/MinerPL/731977099ca84bef7ad0a66978010045/raw/stable.headers.json",
+                            innerCancellationToken
+                        );
+
+                        var userHeaders = JsonSerializer.Deserialize<Dictionary<string, string>>(headersJson);
+                        if (userHeaders is not null)
+                        {
+                            foreach (var kv in userHeaders)
+                                request.Headers.TryAddWithoutValidation(kv.Key, kv.Value);
+                        }
+                    }
+                    catch
+                    {
+
+                    }
+                }
+
 
                 var response = await Http.Client.SendAsync(
                     request,

--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -75,51 +75,59 @@ public class DiscordClient(
             {
                 try
                 {
-                    using var apiReq = new HttpRequestMessage(
-                        HttpMethod.Post,
-                        "https://cordapi.dolfi.es/api/v2/properties/web"
-                    );
+                    // Cache headers from the external API so we don't make this request on every call.
+                    static Dictionary<string, string>? cachedHeaders;
 
-                    using var apiRes = await Http.Client.SendAsync(apiReq, innerCancellationToken);
-                    apiRes.EnsureSuccessStatusCode();
-
-                    var apiJson = await apiRes.Content.ReadAsStringAsync(innerCancellationToken);
-
-                    using var doc = JsonDocument.Parse(apiJson);
-
-                    var root = doc.RootElement;
-
-                    string xspBase64 = root.GetProperty("encoded").GetString()!;
-
-                    var properties = root.GetProperty("properties");
-
-                    string userAgent = proprties.GetProperty("user_agent").GetString()!;
-                    string browserVersion = proprties.GetProperty("browser_version").GetString()!;
-                    string osType = properties.GetProperty("os").GetString()!;
-
-                    string chromeMajor = browserVersion.Split('.')[0];
-
-                    var headers = new Dictionary<string, string>
+                    if (cachedHeaders is null)
                     {
-                        ["sec-ch-ua-platform"] = $"\"{osType}\"",
-                        ["referer"] = "https://discord.com/app",
-                        ["x-debug-options"] = "bugReporterEnabled",
-                        ["accept-language"] = "en-US,en;q=0.9",
+                        using var apiReq = new HttpRequestMessage(
+                            HttpMethod.Post,
+                            "https://cordapi.dolfi.es/api/v2/properties/web"
+                        );
 
-                        ["sec-ch-ua"] =
-                            $"\"Chromium\";v=\"{chromeMajor}\", \"Not;A=Brand\";v=\"99\"",
+                        using var apiRes = await Http.Client.SendAsync(apiReq, innerCancellationToken);
+                        apiRes.EnsureSuccessStatusCode();
 
-                        ["sec-ch-ua-mobile"] = "?0",
+                        var apiJson = await apiRes.Content.ReadAsStringAsync(innerCancellationToken);
 
-                        ["x-discord-timezone"] = "Europe/Warsaw",
-                        ["x-context-properties"] = "eyJsb2NhdGlvbiI6Ii9hcHAifQ==",
-                        ["x-discord-locale"] = "en-US",
+                        using var doc = JsonDocument.Parse(apiJson);
 
-                        ["user-agent"] = userAgent,
-                        ["x-super-properties"] = xspBase64,
-                    };
+                        var root = doc.RootElement;
 
-                    foreach (var kv in headers)
+                        string xspBase64 = root.GetProperty("encoded").GetString()!;
+
+                        var properties = root.GetProperty("properties");
+
+                        string userAgent = properties.GetProperty("user_agent").GetString()!;
+                        string browserVersion = properties.GetProperty("browser_version").GetString()!;
+                        string osType = properties.GetProperty("os").GetString()!;
+
+                        string chromeMajor = browserVersion.Split('.')[0];
+
+                        var headers = new Dictionary<string, string>
+                        {
+                            ["sec-ch-ua-platform"] = $"\"{osType}\"",
+                            ["referer"] = "https://discord.com/app",
+                            ["x-debug-options"] = "bugReporterEnabled",
+                            ["accept-language"] = "en-US,en;q=0.9",
+
+                            ["sec-ch-ua"] =
+                                $"\"Chromium\";v=\"{chromeMajor}\", \"Not;A=Brand\";v=\"99\"",
+
+                            ["sec-ch-ua-mobile"] = "?0",
+
+                            ["x-discord-timezone"] = "Europe/Warsaw",
+                            ["x-context-properties"] = "eyJsb2NhdGlvbiI6Ii9hcHAifQ==",
+                            ["x-discord-locale"] = "en-US",
+
+                            ["user-agent"] = userAgent,
+                            ["x-super-properties"] = xspBase64,
+                        };
+
+                        cachedHeaders = headers;
+                    }
+
+                    foreach (var kv in cachedHeaders)
                         request.Headers.TryAddWithoutValidation(kv.Key, kv.Value);
                 }
                 catch { }

--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -69,90 +69,61 @@ public class DiscordClient(
                     tokenKind == TokenKind.Bot ? $"Bot {token}" : token
                 );
 
-                // add browser headers like x-super-properties and user-agent
-                // discord flags requests that don't look like a real browser
-                if (tokenKind != TokenKind.Bot)
+            // add browser headers like x-super-properties and user-agent
+            // discord flags requests that don't look like a real browser
+            if (tokenKind != TokenKind.Bot)
+            {
+                try
                 {
-                    try
+                    using var apiReq = new HttpRequestMessage(
+                        HttpMethod.Post,
+                        "https://cordapi.dolfi.es/api/v2/properties/web"
+                    );
+
+                    using var apiRes = await Http.Client.SendAsync(apiReq, innerCancellationToken);
+                    apiRes.EnsureSuccessStatusCode();
+
+                    var apiJson = await apiRes.Content.ReadAsStringAsync(innerCancellationToken);
+
+                    using var doc = JsonDocument.Parse(apiJson);
+
+                    var root = doc.RootElement;
+
+                    string xspBase64 = root.GetProperty("encoded").GetString()!;
+
+                    var properties = root.GetProperty("properties");
+
+                    string userAgent = proprties.GetProperty("user_agent").GetString()!;
+                    string browserVersion = proprties.GetProperty("browser_version").GetString()!;
+                    string osType = properties.GetProperty("os").GetString()!;
+
+                    string chromeMajor = browserVersion.Split('.')[0];
+
+                    var headers = new Dictionary<string, string>
                     {
-                        var apiJson = await Http.Client.GetStringAsync(
-                            "https://cordapi.dolfi.es/api/v2/properties/web",
-                            innerCancellationToken
-                        );
+                        ["sec-ch-ua-platform"] = $"\"{osType}\"",
+                        ["referer"] = "https://discord.com/app",
+                        ["x-debug-options"] = "bugReporterEnabled",
+                        ["accept-language"] = "en-US,en;q=0.9",
 
-                        using var doc = JsonDocument.Parse(apiJson);
+                        ["sec-ch-ua"] =
+                            $"\"Chromium\";v=\"{chromeMajor}\", \"Not;A=Brand\";v=\"99\"",
 
-                        var client = doc.RootElement.GetProperty("client");
-                        var browser = doc.RootElement.GetProperty("browser");
-                        var os = browser.GetProperty("os");
+                        ["sec-ch-ua-mobile"] = "?0",
 
-                        string userAgent = browser.GetProperty("user_agent").GetString()!;
-                        string browserVersion = browser.GetProperty("version").GetString()!;
-                        string browserType = browser.GetProperty("type").GetString()!;
-                        string osType = os.GetProperty("type").GetString()!;
-                        string osVersion = os.GetProperty("version").GetString()!;
+                        ["x-discord-timezone"] = "Europe/Warsaw",
+                        ["x-context-properties"] = "eyJsb2NhdGlvbiI6Ii9hcHAifQ==",
+                        ["x-discord-locale"] = "en-US",
 
-                        int buildNumber = client.GetProperty("build_number").GetInt32();
-                        string releaseChannel = client.GetProperty("release_channel").GetString()!;
+                        ["user-agent"] = userAgent,
+                        ["x-super-properties"] = xspBase64,
+                    };
 
-                        string chromeMajor = browserVersion.Split('.')[0];
-
-                        var xsp = new Dictionary<string, object?>
-                        {
-                            ["os"] = osType,
-                            ["browser"] = browserType,
-                            ["device"] = "",
-                            ["system_locale"] = "en-US",
-
-                            ["browser_user_agent"] = userAgent,
-                            ["browser_version"] = browserVersion,
-                            ["os_version"] = osVersion,
-
-                            ["referrer"] = "",
-                            ["referring_domain"] = "",
-                            ["referrer_current"] = "https://www.google.com/",
-                            ["referring_domain_current"] = "www.google.com",
-                            ["search_engine_current"] = "google",
-                            ["mp_keyword_current"] = "discord",
-
-                            ["release_channel"] = releaseChannel,
-                            ["client_build_number"] = buildNumber,
-                            ["client_event_source"] = null,
-                            ["has_client_mods"] = false,
-
-                            ["client_launch_id"] = GenerateUuid(),
-                            ["launch_signature"] = GenerateLaunchSignature(),
-                            ["client_heartbeat_session_id"] = GenerateUuid(),
-                        };
-
-                        var xspJson = JsonSerializer.Serialize(xsp);
-                        var xspBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(xspJson));
-
-                        var headers = new Dictionary<string, string>
-                        {
-                            ["sec-ch-ua-platform"] = $"\"{osType}\"",
-                            ["referer"] = "https://discord.com/app",
-                            ["x-debug-options"] = "bugReporterEnabled",
-                            ["accept-language"] = "en-US,en;q=0.9",
-
-                            ["sec-ch-ua"] =
-                                $"\"Chromium\";v=\"{chromeMajor}\", \"Not;A=Brand\";v=\"99\"",
-
-                            ["sec-ch-ua-mobile"] = "?0",
-
-                            ["x-discord-timezone"] = "Europe/Warsaw",
-                            ["x-context-properties"] = "eyJsb2NhdGlvbiI6Ii9hcHAifQ==",
-                            ["x-discord-locale"] = "en-US",
-
-                            ["user-agent"] = userAgent,
-                            ["x-super-properties"] = xspBase64,
-                        };
-
-                        foreach (var kv in headers)
-                            request.Headers.TryAddWithoutValidation(kv.Key, kv.Value);
-                    }
-                    catch { }
+                    foreach (var kv in headers)
+                        request.Headers.TryAddWithoutValidation(kv.Key, kv.Value);
                 }
+                catch { }
+            }
 
                 var response = await Http.Client.SendAsync(
                     request,

--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -74,7 +74,7 @@ public class DiscordClient(
 
                         var properties = root.GetProperty("properties");
 
-                        string userAgent = properties.GetProperty("user_agent").GetString()!;
+                        string userAgent = properties.GetProperty("browser_user_agent").GetString()!;
                         string browserVersion = properties.GetProperty("browser_version").GetString()!;
                         string osType = properties.GetProperty("os").GetString()!;
 

--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -50,7 +50,7 @@ public class DiscordClient(
             // discord flags requests that don't look like a real browser
             if (tokenKind != TokenKind.Bot)
             {
-                await Task.Run(async () =>
+                try
                 {
                     // Cache headers from the external API so we don't make this request on every call.
 
@@ -105,7 +105,8 @@ public class DiscordClient(
 
                     foreach (var kv in _cachedBrowserHeaders)
                          if (!request.Headers.Contains(kv.Key)) request.Headers.TryAddWithoutValidation(kv.Key, kv.Value);
-                })
+                } 
+                catch {}
             }
 
                 var response = await Http.Client.SendAsync(


### PR DESCRIPTION
As explained in the first commit description, the x-super-properties header is an important header that if not present may cause discord to flag requests or even worse ban/restrict accounts.
The added code uses this [source](https://gist.githubusercontent.com/MinerPL/731977099ca84bef7ad0a66978010045) to add headers that match a normal browser using the discord web client.

possibly closes #1497  
