### PR TITLE
Render polls in HTML exports

### DIFF
--- a/DiscordChatExporter.Core/Discord/Data/Message.cs
+++ b/DiscordChatExporter.Core/Discord/Data/Message.cs
@@ -23,6 +23,7 @@ public partial record Message(
     IReadOnlyList<Attachment> Attachments,
     IReadOnlyList<Embed> Embeds,
     IReadOnlyList<Sticker> Stickers,
+    JsonElement? PollJson,
     IReadOnlyList<Reaction> Reactions,
     IReadOnlyList<User> MentionedUsers,
     MessageReference? Reference,
@@ -35,7 +36,8 @@ public partial record Message(
         string.IsNullOrWhiteSpace(Content)
         && !Attachments.Any()
         && !Embeds.Any()
-        && !Stickers.Any();
+        && !Stickers.Any()
+        && PollJson is null;
 
     public bool IsSystemNotification { get; } =
         Kind is >= MessageKind.RecipientAdd and <= MessageKind.ThreadCreated;
@@ -161,6 +163,8 @@ public partial record Message
                 .ToArray()
             ?? [];
 
+        var poll = json.GetPropertyOrNull("poll");
+
         var reactions =
             json.GetPropertyOrNull("reactions")
                 ?.EnumerateArrayOrNull()
@@ -200,6 +204,7 @@ public partial record Message
             attachments,
             embeds,
             stickers,
+            poll,
             reactions,
             mentionedUsers,
             messageReference,

--- a/DiscordChatExporter.Core/Exporting/MessageGroupTemplate.cshtml
+++ b/DiscordChatExporter.Core/Exporting/MessageGroupTemplate.cshtml
@@ -32,6 +32,17 @@
         Context.Request.ShouldFormatMarkdown
             ? await HtmlMarkdownVisitor.FormatAsync(Context, markdown, false, CancellationToken)
             : markdown;
+
+    async ValueTask<string?> GetPollAnswerTextAsync(JsonElement answer)
+    {
+        var pollMedia = answer.GetPropertyOrNull("poll_media");
+        var text = pollMedia?.GetPropertyOrNull("text")?.GetStringOrNull();
+
+        if (string.IsNullOrWhiteSpace(text))
+            return null;
+
+        return await FormatMarkdownAsync(text);
+    }
 }
 
 <div class="chatlog__message-group">
@@ -730,6 +741,34 @@
                                 </div>
                             </div>
                         }
+                    }
+
+
+                    @* Poll *@
+                    @if (message.PollJson is not null)
+                    {
+                        var poll = message.PollJson.Value;
+                        var questionText = poll
+                            .GetPropertyOrNull("question")
+                            ?.GetPropertyOrNull("text")
+                            ?.GetStringOrNull();
+
+                        <div class="chatlog__poll">
+                            @if (!string.IsNullOrWhiteSpace(questionText))
+                            {
+                                <div class="chatlog__poll-question">@(await FormatMarkdownAsync(questionText))</div>
+                            }
+
+                            @foreach (var answer in poll.GetPropertyOrNull("answers")?.EnumerateArrayOrNull() ?? [])
+                            {
+                                var answerText = await GetPollAnswerTextAsync(answer);
+
+                                @if (!string.IsNullOrWhiteSpace(answerText))
+                                {
+                                    <div class="chatlog__poll-answer">@answerText</div>
+                                }
+                            }
+                        </div>
                     }
 
                     @* Stickers *@

--- a/DiscordChatExporter.Core/Exporting/PreambleTemplate.cshtml
+++ b/DiscordChatExporter.Core/Exporting/PreambleTemplate.cshtml
@@ -764,6 +764,32 @@
             cursor: pointer;
         }
 
+
+        .chatlog__poll {
+            display: inline-block;
+            min-width: 260px;
+            max-width: 520px;
+            margin-top: 0.25rem;
+            padding: 0.75rem;
+            border: 1px solid @Themed("#3f4147", "#d6d9dc");
+            border-radius: 8px;
+            background-color: @Themed("#2f3136", "#f2f3f5");
+        }
+
+        .chatlog__poll-question {
+            margin-bottom: 0.5rem;
+            color: @Themed("#fff", "#2e3338");
+            font-weight: 600;
+        }
+
+        .chatlog__poll-answer {
+            margin-top: 0.35rem;
+            padding: 0.35rem 0.5rem;
+            border-radius: 6px;
+            background-color: @Themed("#36393f", "#fff");
+            color: @Themed("#dcddde", "#2e3338");
+        }
+
         .chatlog__sticker {
             width: 180px;
             height: 180px;


### PR DESCRIPTION
Adds basic poll support to HTML exports by preserving the raw poll payload from Discord messages and rendering the poll question and available answers alongside the existing message content. Poll-only messages are no longer treated as empty, so they are included in the exported output instead of only showing their reaction data. Verified with `git diff --check` and targeted content assertions; a full build could not be run because `dotnet` is not installed in this environment.
