### PR TITLE
Render poll data in HTML exports

### DIFF
--- a/DiscordChatExporter.Core/Discord/Data/Message.cs
+++ b/DiscordChatExporter.Core/Discord/Data/Message.cs
@@ -28,14 +28,16 @@ public partial record Message(
     MessageReference? Reference,
     Message? ReferencedMessage,
     MessageSnapshot? ForwardedMessage,
-    Interaction? Interaction
+    Interaction? Interaction,
+    JsonElement? Poll
 ) : IHasId
 {
     public bool IsEmpty { get; } =
         string.IsNullOrWhiteSpace(Content)
         && !Attachments.Any()
         && !Embeds.Any()
-        && !Stickers.Any();
+        && !Stickers.Any()
+        && Poll is null;
 
     public bool IsSystemNotification { get; } =
         Kind is >= MessageKind.RecipientAdd and <= MessageKind.ThreadCreated;
@@ -187,6 +189,8 @@ public partial record Message
 
         var interaction = json.GetPropertyOrNull("interaction")?.Pipe(Interaction.Parse);
 
+        var poll = json.GetPropertyOrNull("poll");
+
         return new Message(
             id,
             kind,
@@ -205,7 +209,8 @@ public partial record Message
             messageReference,
             referencedMessage,
             forwardedMessage,
-            interaction
+            interaction,
+            poll
         );
     }
 }

--- a/DiscordChatExporter.Core/Exporting/MessageGroupTemplate.cshtml
+++ b/DiscordChatExporter.Core/Exporting/MessageGroupTemplate.cshtml
@@ -400,6 +400,35 @@
                         </div>
                     }
 
+                    @* Poll *@
+                    @if (message.Poll is not null)
+                    {
+                        var pollQuestion = message.Poll.Value
+                            .GetPropertyOrNull("question")?
+                            .GetPropertyOrNull("text")?
+                            .GetStringOrNull();
+
+                        <div class="chatlog__poll">
+                            @if (!string.IsNullOrWhiteSpace(pollQuestion))
+                            {
+                                <div class="chatlog__poll-question"><!--wmm:ignore-->@Html.Raw(await FormatMarkdownAsync(pollQuestion))<!--/wmm:ignore--></div>
+                            }
+
+                            @foreach (var answer in message.Poll.Value.GetPropertyOrNull("answers")?.EnumerateArrayOrNull() ?? [])
+                            {
+                                var answerText = answer
+                                    .GetPropertyOrNull("poll_media")?
+                                    .GetPropertyOrNull("text")?
+                                    .GetStringOrNull();
+
+                                if (!string.IsNullOrWhiteSpace(answerText))
+                                {
+                                    <div class="chatlog__poll-answer"><!--wmm:ignore-->@Html.Raw(await FormatMarkdownAsync(answerText))<!--/wmm:ignore--></div>
+                                }
+                            }
+                        </div>
+                    }
+
                     @* Invites *@
                     @{
                         var inviteCodes = MarkdownParser

--- a/DiscordChatExporter.Core/Exporting/PreambleTemplate.cshtml
+++ b/DiscordChatExporter.Core/Exporting/PreambleTemplate.cshtml
@@ -430,6 +430,27 @@
             font-weight: 500;
         }
 
+        .chatlog__poll {
+            max-width: 520px;
+            margin-top: 0.3rem;
+            padding: 0.75rem;
+            border: 1px solid @Themed("#4f545c", "#d4d7dc");
+            border-radius: 8px;
+            background-color: @Themed("#2f3136", "#f2f3f5");
+        }
+
+        .chatlog__poll-question {
+            margin-bottom: 0.5rem;
+            font-weight: 600;
+        }
+
+        .chatlog__poll-answer {
+            margin-top: 0.35rem;
+            padding: 0.45rem 0.6rem;
+            border-radius: 4px;
+            background-color: @Themed("#36393f", "#ffffff");
+        }
+
         .chatlog__attachment {
             position: relative;
             width: fit-content;


### PR DESCRIPTION
This adds basic HTML rendering for Discord poll payloads by preserving the raw poll data on parsed messages, treating poll-only messages as non-empty, and outputting the poll question and answers in the message body. I could not run the .NET test suite in this environment because the `dotnet` CLI is not installed, but `git diff --check` passes.
