### PR TITLE
Stream asset downloads to avoid OutOfMemoryException on large files

### DIFF
--- a/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
@@ -64,15 +64,15 @@ internal partial class ExportAssetDownloader(string workingDirPath, bool reuse)
         await Http.ResiliencePipeline.ExecuteAsync(
             async innerCancellationToken =>
             {
-                // Download the file.
-                // Use ResponseHeadersRead so the response body is streamed to disk instead of
-                // being fully buffered into memory first, which can cause an OutOfMemoryException
-                // on large attachments.
+                // Download the file
                 using var response = await Http.Client.GetAsync(
                     url,
                     HttpCompletionOption.ResponseHeadersRead,
                     innerCancellationToken
                 );
+
+                response.EnsureSuccessStatusCode();
+
                 await using var output = File.Create(filePath);
                 await response.Content.CopyToAsync(output, innerCancellationToken);
             },

--- a/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
@@ -63,8 +64,15 @@ internal partial class ExportAssetDownloader(string workingDirPath, bool reuse)
         await Http.ResiliencePipeline.ExecuteAsync(
             async innerCancellationToken =>
             {
-                // Download the file
-                using var response = await Http.Client.GetAsync(url, innerCancellationToken);
+                // Download the file.
+                // Use ResponseHeadersRead so the response body is streamed to disk instead of
+                // being fully buffered into memory first, which can cause an OutOfMemoryException
+                // on large attachments.
+                using var response = await Http.Client.GetAsync(
+                    url,
+                    HttpCompletionOption.ResponseHeadersRead,
+                    innerCancellationToken
+                );
                 await using var output = File.Create(filePath);
                 await response.Content.CopyToAsync(output, innerCancellationToken);
             },


### PR DESCRIPTION
Exporting a channel with **Download assets** enabled crashes with an `OutOfMemoryException` as soon as it hits a large attachment

```
System.OutOfMemoryException
  at System.Net.Http.HttpContent.LimitArrayPoolWriteStream.GrowAndWrite(...)
  at System.Net.Http.HttpConnection.CopyToContentLengthAsync(...)
  at System.Net.Http.HttpContent.LoadIntoBufferAsyncCore(...)
  at DiscordChatExporter.Core.Exporting.ExportAssetDownloader.DownloadAsync(...)
```

`DownloadAsync` calls `Http.Client.GetAsync(url, ct)`, which defaults to `HttpCompletionOption.ResponseContentRead`. That buffers the entire response into memory before returning, so for a big attachment it tries to allocate a buffer the size of the whole file and OOMs before `CopyToAsync` ever writes anything to disk

### Fix

Use `ResponseHeadersRead` instead, so `GetAsync` returns once the headers are in and `CopyToAsync` streams the body to disk in chunks. `DiscordClient` already does this for its own requests.

Built a `win-x64` self-contained GUI from this branch and the export that was crashing now finishes.