### PR TITLE
Catch both old uppercase 5-char hash and newer lowercase 5-char hash when migrating to new hash

### DIFF
--- a/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
@@ -149,11 +149,7 @@ internal partial class ExportAssetDownloader
         return
         [
             // Lowercase variant (introduced in 2.46.1)
-            GetFileNameFromUrl(
-                url,
-                Convert.ToHexStringLower(hashData).Truncate(5)
-            ),
-
+            GetFileNameFromUrl(url, Convert.ToHexStringLower(hashData).Truncate(5)),
             // Uppercase variant (original)
             GetFileNameFromUrl(
                 url,

--- a/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
@@ -38,8 +38,8 @@ internal partial class ExportAssetDownloader(string workingDirPath, bool reuse)
             return _previousPathsByUrl[url] = filePath;
 
         // Check for a file cached by the legacy naming scheme (5-char hash) and rename it
-        // to the new naming scheme to preserve backwards compatibility with existing exports
-        // This will catch both the 5-char lowercase hash and the 5-char uppercase hash variants
+        // to the new naming scheme to preserve backwards compatibility with existing exports.
+        // This will catch both the 5-char lowercase hash and the 5-char uppercase hash variants.
         if (reuse)
         {
             var legacyFileNames = GetLegacyFileNamesFromUrl(url);
@@ -52,7 +52,7 @@ internal partial class ExportAssetDownloader(string workingDirPath, bool reuse)
                     // earlier existence check and this move operation
                     try
                     {
-                        File.Move(legacyFilePath, filePath, overwrite: true);
+                        File.Move(legacyFilePath, filePath, true);
                         return _previousPathsByUrl[url] = filePath;
                     }
                     catch (IOException)
@@ -142,7 +142,7 @@ internal partial class ExportAssetDownloader
         );
 
     // Legacy naming used a 5-char hash, kept for backwards compatibility with existing exports
-    private static string[] GetLegacyFileNamesFromUrl(string url)
+    private static IReadOnlyList<string> GetLegacyFileNamesFromUrl(string url)
     {
         var hashData = SHA256.HashData(Encoding.UTF8.GetBytes(NormalizeUrl(url)));
 

--- a/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
@@ -39,22 +39,27 @@ internal partial class ExportAssetDownloader(string workingDirPath, bool reuse)
 
         // Check for a file cached by the legacy naming scheme (5-char hash) and rename it
         // to the new naming scheme to preserve backwards compatibility with existing exports
+        // This will catch both the 5-char lowercase hash and the 5-char uppercase hash variants
         if (reuse)
         {
-            var legacyFilePath = Path.Combine(workingDirPath, GetLegacyFileNameFromUrl(url));
-            if (File.Exists(legacyFilePath))
+            var legacyFileNames = GetLegacyFileNamesFromUrl(url);
+            foreach (var legacyFileName in legacyFileNames)
             {
-                // Overwrite in case the destination file was created concurrently between our
-                // earlier existence check and this move operation
-                try
+                var legacyFilePath = Path.Combine(workingDirPath, legacyFileName);
+                if (File.Exists(legacyFilePath))
                 {
-                    File.Move(legacyFilePath, filePath, overwrite: true);
-                    return _previousPathsByUrl[url] = filePath;
-                }
-                catch (IOException)
-                {
-                    // The legacy file was moved or deleted concurrently or something else happened.
-                    // Upgrading old files is not crucial, so we can just move on.
+                    // Overwrite in case the destination file was created concurrently between our
+                    // earlier existence check and this move operation
+                    try
+                    {
+                        File.Move(legacyFilePath, filePath, overwrite: true);
+                        return _previousPathsByUrl[url] = filePath;
+                    }
+                    catch (IOException)
+                    {
+                        // The legacy file was moved or deleted concurrently or something else happened.
+                        // Upgrading old files is not crucial, so we can just move on.
+                    }
                 }
             }
         }
@@ -137,13 +142,23 @@ internal partial class ExportAssetDownloader
         );
 
     // Legacy naming used a 5-char hash, kept for backwards compatibility with existing exports
-    private static string GetLegacyFileNameFromUrl(string url) =>
-        GetFileNameFromUrl(
-            url,
-            SHA256
-                .HashData(Encoding.UTF8.GetBytes(NormalizeUrl(url)))
-                .Pipe(Convert.ToHexStringLower)
-                // 5 chars = 20 bits, reaches 1% collision probability at ~145 files
-                .Truncate(5)
-        );
+    private static string[] GetLegacyFileNamesFromUrl(string url)
+    {
+        var hashData = SHA256.HashData(Encoding.UTF8.GetBytes(NormalizeUrl(url)));
+
+        return
+        [
+            // Lowercase variant (introduced in 2.46.1)
+            GetFileNameFromUrl(
+                url,
+                Convert.ToHexStringLower(hashData).Truncate(5)
+            ),
+
+            // Uppercase variant (original)
+            GetFileNameFromUrl(
+                url,
+                Convert.ToHexString(hashData).Truncate(5)
+            )
+        ];
+    }
 }


### PR DESCRIPTION
This fixes a bug with the media export

Originally, file hashes were generated using a 5-character all **uppercase** hex hash. In a more recent version of this tool (2.46.1, [this commit](https://github.com/Tyrrrz/DiscordChatExporter/commit/768e124370c42c62c3eef269b8d039dbe6beeed6)), it was changed to a 5-character all **lowercase** hex hash. In the most recent version, the 5-character hex hash has been updated to a 16-character hash, with support for renaming files that were generated using the previous hash method.

However, this renaming process does not include a check for the original 5-character uppercase hash file. So files that were generated with the uppercase hash are ignored, and only files with the lowercase hash are detected and renamed. If a piece of media was deleted at the source (e.g. deleted from twitter) and can no longer be re-fetched, that media is treated as inaccessible even if the media was already exported using the 5-char uppercase file hash. **The file exists on disk already from a previous export, but the code does not detect it since it's only looking for files with a lowercase hash.**

This PR adds support for detecting files that were generated with the original uppercase hash as well as the newer lowercase hash.

<!-- Please specify the issue(s) addressed by this pull request: -->

Closes #1551 

<!--

Also keep in mind:

- Pull requests should be as small as possible. Split larger changes into multiple pull requests if needed.
- Follow the coding style and conventions already established in the project. When in doubt, ask in the comments.
- You can add review comments to your own code. Use this to highlight something important or to seek further input from reviewers.

-->
