### PR TITLE
Check for `media.discordapp.net` in addition to `cdn.discordapp.com` when stripping signature parameters from media URLs

### DIFF
--- a/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
@@ -90,8 +90,10 @@ internal partial class ExportAssetDownloader
         // Remove signature parameters from Discord CDN/media URLs to normalize them
         var uri = new Uri(url);
 
-        if (!string.Equals(uri.Host, "cdn.discordapp.com", StringComparison.OrdinalIgnoreCase) &&
-            !string.Equals(uri.Host, "media.discordapp.net", StringComparison.OrdinalIgnoreCase))
+        if (
+            !string.Equals(uri.Host, "cdn.discordapp.com", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(uri.Host, "media.discordapp.net", StringComparison.OrdinalIgnoreCase)
+        )
         {
             return url;
         }

--- a/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportAssetDownloader.cs
@@ -87,10 +87,14 @@ internal partial class ExportAssetDownloader
 {
     private static string NormalizeUrl(string url)
     {
-        // Remove signature parameters from Discord CDN URLs to normalize them
+        // Remove signature parameters from Discord CDN/media URLs to normalize them
         var uri = new Uri(url);
-        if (!string.Equals(uri.Host, "cdn.discordapp.com", StringComparison.OrdinalIgnoreCase))
+
+        if (!string.Equals(uri.Host, "cdn.discordapp.com", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(uri.Host, "media.discordapp.net", StringComparison.OrdinalIgnoreCase))
+        {
             return url;
+        }
 
         var query = HttpUtility.ParseQueryString(uri.Query);
         query.Remove("ex");


### PR DESCRIPTION
Check for media.discordapp.net when stripping signature parameters from discord media urls during exports

<!-- Please specify the issue(s) addressed by this pull request: -->

Closes #1553

<!--

Also keep in mind:

- Pull requests should be as small as possible. Split larger changes into multiple pull requests if needed.
- Follow the coding style and conventions already established in the project. When in doubt, ask in the comments.
- You can add review comments to your own code. Use this to highlight something important or to seek further input from reviewers.

-->
