### PR TITLE
Fix output path detection to correctly identify directories and files

### DIFF
--- a/DiscordChatExporter.Core/Exporting/ExportRequest.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportRequest.cs
@@ -206,10 +206,15 @@ public partial class ExportRequest
     {
         var actualOutputPath = FormatPath(outputPath, guild, channel, after, before);
 
-        // Output is a directory
+        // Determine whether the output path refers to a directory or a file.
+        // The extension-based heuristic is evaluated on the original, unsubstituted path,
+        // because the value of a template token (e.g. a guild or channel name) may contain
+        // a period that would otherwise be mistaken for a file extension, incorrectly causing
+        // a directory path to be treated as a file.
+        // https://github.com/Tyrrrz/DiscordChatExporter/issues/1502
         if (
             Directory.Exists(actualOutputPath)
-            || string.IsNullOrWhiteSpace(Path.GetExtension(actualOutputPath))
+            || string.IsNullOrWhiteSpace(Path.GetExtension(outputPath))
         )
         {
             var fileName = GetDefaultOutputFileName(guild, channel, format, after, before);


### PR DESCRIPTION
Related to issue #1502

https://github.com/Tyrrrz/DiscordChatExporter/blob/acac8f7bbb7fc080ca0b4a06756929c4a68af09c/DiscordChatExporter.Core/Exporting/ExportRequest.cs#L207-L220

Issue: You use `%G` at the end of a path with the guild name containing a period. The heuristic from the code snippet above identifies the resolved server name as a file path as `Path.GetExtension(actualOutputPath)` does not return `Null`. DCE then tries to export all channels into this one file, e.g., `Discord.Test`, leading to a `System.IO.IOException` due to concurrent access to one file by multiple processes if the export is parallelized.

Solution: Evaluate the extension-based heuristic on the original, unsubstituted `outputPath` instead of the resolved path. The template path has no unwanted extension and therefore the user intent of creating a directory is preserved.