### PR TITLE
Include starter message in thread exports and skip placeholder

### DIFF
--- a/DiscordChatExporter.Core/Discord/Data/MessageKind.cs
+++ b/DiscordChatExporter.Core/Discord/Data/MessageKind.cs
@@ -13,4 +13,5 @@ public enum MessageKind
     GuildMemberJoin = 7,
     ThreadCreated = 18,
     Reply = 19,
+    ThreadStarterMessage = 21,
 }

--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -656,6 +656,33 @@ public class DiscordClient(
             .FirstOrDefault(m => m.Id == messageId);
     }
 
+    private async ValueTask<Message?> ResolveThreadStarterMessageAsync(
+        Message message,
+        CancellationToken cancellationToken = default
+    )
+    {
+        // Threads created from a message contain an empty THREAD_STARTER_MESSAGE placeholder at
+        // the top of their history (in place of the actual starter message) that merely points
+        // back to the originating message in the parent channel. Resolve the placeholder to that
+        // actual message so the thread's starter message appears in the output, in its correct
+        // chronological position, with its real content.
+        // This doesn't apply to forum/media posts, whose starter message is already a regular
+        // message in the thread's own history (i.e. not a placeholder).
+        // https://github.com/Tyrrrz/DiscordChatExporter/issues/1265
+        if (message.Kind != MessageKind.ThreadStarterMessage)
+            return message;
+
+        // The placeholder references the parent channel and the original message it points to.
+        if (message.Reference?.ChannelId is not { } channelId)
+            return null;
+        if (message.Reference?.MessageId is not { } messageId)
+            return null;
+
+        // The original message may no longer be accessible (e.g. deleted), in which case the
+        // empty placeholder is dropped as well.
+        return await TryGetMessageAsync(channelId, messageId, cancellationToken);
+    }
+
     public async IAsyncEnumerable<Message> GetMessagesAsync(
         Snowflake channelId,
         Snowflake? after = null,
@@ -728,7 +755,15 @@ public class DiscordClient(
                     );
                 }
 
-                yield return message;
+                // Thread starter messages are returned as empty placeholders; resolve them to
+                // the actual message they reference before yielding (or skip if unavailable).
+                var resolvedMessage = await ResolveThreadStarterMessageAsync(
+                    message,
+                    cancellationToken
+                );
+                if (resolvedMessage is not null)
+                    yield return resolvedMessage;
+
                 currentAfter = message.Id;
             }
         }
@@ -796,7 +831,14 @@ public class DiscordClient(
                     );
                 }
 
-                yield return message;
+                // Thread starter messages are returned as empty placeholders; resolve them to
+                // the actual message they reference before yielding (or skip if unavailable).
+                var resolvedMessage = await ResolveThreadStarterMessageAsync(
+                    message,
+                    cancellationToken
+                );
+                if (resolvedMessage is not null)
+                    yield return resolvedMessage;
             }
 
             currentBefore = messages.Last().Id;

--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -629,6 +629,33 @@ public class DiscordClient(
         return response.EnumerateArray().Select(Message.Parse).LastOrDefault();
     }
 
+    public async ValueTask<Message?> TryGetMessageAsync(
+        Snowflake channelId,
+        Snowflake messageId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        // Use the regular message listing endpoint with the 'around' parameter instead of the
+        // dedicated single-message endpoint, because the latter is not accessible to user tokens.
+        var url = new UrlBuilder()
+            .SetPath($"channels/{channelId}/messages")
+            .SetQueryParameter("around", messageId.ToString())
+            .SetQueryParameter("limit", "1")
+            .Build();
+
+        // Can be null on channels that the user cannot access
+        var response = await TryGetJsonResponseAsync(url, cancellationToken);
+        if (response is null)
+            return null;
+
+        // The endpoint returns messages around the requested ID, so make sure to only return
+        // the message that exactly matches it (it may be absent if it has been deleted).
+        return response
+            .Value.EnumerateArray()
+            .Select(Message.Parse)
+            .FirstOrDefault(m => m.Id == messageId);
+    }
+
     public async IAsyncEnumerable<Message> GetMessagesAsync(
         Snowflake channelId,
         Snowflake? after = null,

--- a/DiscordChatExporter.Core/Exporting/ChannelExporter.cs
+++ b/DiscordChatExporter.Core/Exporting/ChannelExporter.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using DiscordChatExporter.Core.Discord;
@@ -80,7 +82,53 @@ public class ChannelExporter(DiscordClient discord)
                 cancellationToken
             );
 
-        await foreach (var message in messages)
+        // Threads created from a message don't include that message in their own history, even
+        // though it logically belongs to the thread as its very first message. Because the thread
+        // shares its ID with that starter message, we can fetch it from the parent channel and
+        // export it together with the rest of the thread's messages.
+        // This doesn't apply to forum/media posts, whose starter message is already part of the
+        // thread's own history.
+        // https://github.com/Tyrrrz/DiscordChatExporter/issues/1265
+        var starterMessage =
+            request.Channel.IsThread
+            && request.Channel.Parent is { Kind: not ChannelKind.GuildForum } parent
+                ? await discord.TryGetMessageAsync(parent.Id, request.Channel.Id, cancellationToken)
+                : null;
+
+        // Only include the starter message if it falls within the requested range
+        if (
+            starterMessage is not null
+            && (
+                (request.After is not null && starterMessage.Id < request.After.Value)
+                || (request.Before is not null && starterMessage.Id > request.Before.Value)
+            )
+        )
+        {
+            starterMessage = null;
+        }
+
+        // Prepend the starter message to the thread's history, or append it when exporting in
+        // reverse order, so that it remains the oldest message in the output either way.
+        async IAsyncEnumerable<Message> GetMessagesWithStarter(
+            [EnumeratorCancellation] CancellationToken innerCancellationToken
+        )
+        {
+            if (starterMessage is not null && !request.IsReverseMessageOrder)
+                yield return starterMessage;
+
+            await foreach (var message in messages.WithCancellation(innerCancellationToken))
+            {
+                // Avoid exporting the starter message twice in case it's also returned as part
+                // of the thread's own history.
+                if (message.Id != starterMessage?.Id)
+                    yield return message;
+            }
+
+            if (starterMessage is not null && request.IsReverseMessageOrder)
+                yield return starterMessage;
+        }
+
+        await foreach (var message in GetMessagesWithStarter(cancellationToken))
         {
             try
             {

--- a/DiscordChatExporter.Core/Exporting/ChannelExporter.cs
+++ b/DiscordChatExporter.Core/Exporting/ChannelExporter.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using DiscordChatExporter.Core.Discord;
@@ -82,63 +80,7 @@ public class ChannelExporter(DiscordClient discord)
                 cancellationToken
             );
 
-        // Threads created from a message don't include that message in their own history, even
-        // though it logically belongs to the thread as its very first message. Because the thread
-        // shares its ID with that starter message, we can fetch it from the parent channel and
-        // export it together with the rest of the thread's messages.
-        // This doesn't apply to forum/media posts, whose starter message is already part of the
-        // thread's own history.
-        // https://github.com/Tyrrrz/DiscordChatExporter/issues/1265
-        var starterMessage =
-            request.Channel.IsThread
-            && request.Channel.Parent is { Kind: not ChannelKind.GuildForum } parent
-                ? await discord.TryGetMessageAsync(parent.Id, request.Channel.Id, cancellationToken)
-                : null;
-
-        // Only include the starter message if it falls within the requested range
-        if (
-            starterMessage is not null
-            && (
-                (request.After is not null && starterMessage.Id < request.After.Value)
-                || (request.Before is not null && starterMessage.Id > request.Before.Value)
-            )
-        )
-        {
-            starterMessage = null;
-        }
-
-        // Prepend the starter message to the thread's history, or append it when exporting in
-        // reverse order, so that it remains the oldest message in the output either way.
-        async IAsyncEnumerable<Message> GetMessagesWithStarter(
-            [EnumeratorCancellation] CancellationToken innerCancellationToken
-        )
-        {
-            // If the message order is not reversed, the starter message should be the first one in the output, so we yield it before fetching the rest of the thread's history.
-            if (starterMessage is not null && !request.IsReverseMessageOrder)
-                yield return starterMessage;
-
-            // Fetch the rest of the thread's history and yield messages one by one
-            await foreach (var message in messages.WithCancellation(innerCancellationToken))
-            {
-                // A thread created from a message has an empty THREAD_STARTER_MESSAGE placeholder
-                // at the top of its history that merely points back to the originating message.
-                // It never carries any renderable content of its own and is superseded by the
-                // actual starter message fetched above, so skip it.
-                if (message.Kind == MessageKind.ThreadStarterMessage)
-                    continue;
-
-                // Avoid exporting the starter message twice in case it's also returned as part
-                // of the thread's own history.
-                if (message.Id != starterMessage?.Id)
-                    yield return message;
-            }
-
-            // If the message order is reversed, the starter message should be the last one in the output, so we yield it after fetching the rest of the thread's history.
-            if (starterMessage is not null && request.IsReverseMessageOrder)
-                yield return starterMessage;
-        }
-
-        await foreach (var message in GetMessagesWithStarter(cancellationToken))
+        await foreach (var message in messages)
         {
             try
             {

--- a/DiscordChatExporter.Core/Exporting/ChannelExporter.cs
+++ b/DiscordChatExporter.Core/Exporting/ChannelExporter.cs
@@ -113,9 +113,11 @@ public class ChannelExporter(DiscordClient discord)
             [EnumeratorCancellation] CancellationToken innerCancellationToken
         )
         {
+            // If the message order is not reversed, the starter message should be the first one in the output, so we yield it before fetching the rest of the thread's history.
             if (starterMessage is not null && !request.IsReverseMessageOrder)
                 yield return starterMessage;
 
+            // Fetch the rest of the thread's history and yield messages one by one
             await foreach (var message in messages.WithCancellation(innerCancellationToken))
             {
                 // Avoid exporting the starter message twice in case it's also returned as part
@@ -124,6 +126,7 @@ public class ChannelExporter(DiscordClient discord)
                     yield return message;
             }
 
+            // If the message order is reversed, the starter message should be the last one in the output, so we yield it after fetching the rest of the thread's history.
             if (starterMessage is not null && request.IsReverseMessageOrder)
                 yield return starterMessage;
         }

--- a/DiscordChatExporter.Core/Exporting/ChannelExporter.cs
+++ b/DiscordChatExporter.Core/Exporting/ChannelExporter.cs
@@ -120,6 +120,13 @@ public class ChannelExporter(DiscordClient discord)
             // Fetch the rest of the thread's history and yield messages one by one
             await foreach (var message in messages.WithCancellation(innerCancellationToken))
             {
+                // A thread created from a message has an empty THREAD_STARTER_MESSAGE placeholder
+                // at the top of its history that merely points back to the originating message.
+                // It never carries any renderable content of its own and is superseded by the
+                // actual starter message fetched above, so skip it.
+                if (message.Kind == MessageKind.ThreadStarterMessage)
+                    continue;
+
                 // Avoid exporting the starter message twice in case it's also returned as part
                 // of the thread's own history.
                 if (message.Id != starterMessage?.Id)


### PR DESCRIPTION
Attempts to fix #1265

Disclaimer: Code and summary were generated with the help of Copilot

This pull request improves the handling and export of thread starter messages in Discord threads. It ensures that the actual starter message of a thread is included in exports, addressing a previous issue where this message could be missing from the thread's history. The update introduces logic to fetch and correctly position the starter message, while also skipping placeholder messages and preventing duplicates.

Key improvements to thread starter message handling:

* Added a new `MessageKind.ThreadStarterMessage` enum value to distinguish thread starter message placeholders.
* Implemented the `TryGetMessageAsync` method in `DiscordClient` to fetch a specific message from a channel using the `around` parameter, enabling retrieval of thread starter messages even when the dedicated endpoint is inaccessible.

Enhancements to thread export logic:

* Updated `ChannelExporter` to detect when a thread's starter message should be fetched from its parent channel, and to include it in the export if it falls within the requested range. This ensures the thread's starter message is always present in the output.
* Added logic to skip exporting the `ThreadStarterMessage` placeholder and avoid duplicating the actual starter message during export.
* Added missing `using` directives for `System.Collections.Generic` and `System.Runtime.CompilerServices` to support the new asynchronous enumerable logic.