### PR TITLE
Only display http(s) URLs as links in HTML export 

### DIFF
--- a/DiscordChatExporter.Core/Markdown/Parsing/MarkdownParser.cs
+++ b/DiscordChatExporter.Core/Markdown/Parsing/MarkdownParser.cs
@@ -264,7 +264,7 @@ internal static partial class MarkdownParser
     private static readonly IMatcher<MarkdownContext, MarkdownNode> MaskedLinkNodeMatcher =
         new RegexMatcher<MarkdownContext, MarkdownNode>(
             // Capture [title](link)
-            new Regex(@"\[(.+?)\]\((.+?)\)", DefaultRegexOptions),
+            new Regex(@"\[(.+?)\]\((https?://\S*[^\.,:;""'\s])\)", DefaultRegexOptions),
             (c, s, m) => new LinkNode(m.Groups[2].Value, Parse(c, s.Relocate(m.Groups[1])))
         );
 


### PR DESCRIPTION
Closes #1567.

The masked link regex (for links of the type `[title](link)`) was too broad, leading to the possibility of XSS attacks as described in #1567. Discord itself displays these links as plaintext instead of formatting them as markdown, so this PR updates the regex to only match http and https links.

Note: Discord also turns a few other schemes into links (from my testing, this includes mailto, sms, tel, and discord), but DCE doesn't display these as links (except when masked), so I limited this PR to http and https for consistency.