### PR TITLE
Fix reverse exports with an after boundary

### DIFF
--- a/DiscordChatExporter.Cli.Tests/Specs/DateRangeSpecs.cs
+++ b/DiscordChatExporter.Cli.Tests/Specs/DateRangeSpecs.cs
@@ -61,6 +61,52 @@ public class DateRangeSpecs
     }
 
     [Fact]
+    public async Task I_can_filter_the_reverse_export_to_only_include_messages_sent_after_the_specified_date()
+    {
+        // Arrange
+        var after = new DateTimeOffset(2021, 07, 24, 0, 0, 0, TimeSpan.Zero);
+        using var file = TempFile.Create();
+
+        // Act
+        await new ExportChannelsCommand
+        {
+            Token = Secrets.DiscordToken,
+            ChannelIds = [ChannelIds.DateRangeTestCases],
+            ExportFormat = ExportFormat.Json,
+            OutputPath = file.Path,
+            After = Snowflake.FromDate(after),
+            IsReverseMessageOrder = true,
+        }.ExecuteAsync(new FakeConsole());
+
+        // Assert
+        var timestamps = Json.Parse(await File.ReadAllTextAsync(file.Path))
+            .GetProperty("messages")
+            .EnumerateArray()
+            .Select(j => j.GetProperty("timestamp").GetDateTimeOffset())
+            .ToArray();
+
+        timestamps.All(t => t > after).Should().BeTrue();
+        timestamps.Should().BeInDescendingOrder();
+
+        timestamps
+            .Should()
+            .BeEquivalentTo(
+                [
+                    new DateTimeOffset(2021, 09, 08, 14, 26, 35, TimeSpan.Zero),
+                    new DateTimeOffset(2021, 07, 24, 14, 52, 40, TimeSpan.Zero),
+                    new DateTimeOffset(2021, 07, 24, 14, 52, 39, TimeSpan.Zero),
+                    new DateTimeOffset(2021, 07, 24, 14, 52, 38, TimeSpan.Zero),
+                    new DateTimeOffset(2021, 07, 24, 13, 49, 13, TimeSpan.Zero),
+                ],
+                o =>
+                    o.Using<DateTimeOffset>(ctx =>
+                            ctx.Subject.Should().BeCloseTo(ctx.Expectation, TimeSpan.FromSeconds(1))
+                        )
+                        .WhenTypeIs<DateTimeOffset>()
+            );
+    }
+
+    [Fact]
     public async Task I_can_filter_the_export_to_only_include_messages_sent_before_the_specified_date()
     {
         // Arrange

--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -796,6 +796,10 @@ public class DiscordClient(
 
             foreach (var message in messages)
             {
+                // Messages are ordered newest to oldest, so no later message can satisfy this bound.
+                if (after is not null && message.Id.CompareTo(after.Value) <= 0)
+                    yield break;
+
                 lastMessage ??= message;
 
                 // Report progress based on timestamps

--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -796,8 +796,8 @@ public class DiscordClient(
 
             foreach (var message in messages)
             {
-                // Messages are ordered newest to oldest, so no later message can satisfy this bound.
-                if (after is not null && message.Id.CompareTo(after.Value) <= 0)
+                // Ensure that the messages are in range
+                if (message.Timestamp <= after?.ToDate())
                     yield break;
 
                 lastMessage ??= message;


### PR DESCRIPTION
## Summary

- Stop reverse pagination at the requested after boundary.
- Add DateRange coverage for reverse exports with an after boundary.

## Root cause

Reverse pagination used the after boundary to calculate progress but kept fetching and exporting older pages.

## Validation

- Release build passed.
- Formatting verification passed.
