### PR TITLE
Only allow http(s) URLs in exported HTML links (fixes #1575)

### DIFF
--- a/DiscordChatExporter.Core/Exporting/ExportContext.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportContext.cs
@@ -120,6 +120,12 @@ internal class ExportContext(DiscordClient discord, ExportRequest request)
     public Color? TryGetUserColor(Snowflake id) =>
         GetUserRoles(id).Where(r => r.Color is not null).Select(r => r.Color).FirstOrDefault();
 
+    public static string? EnsureSafeUrl(string? url) =>
+        Uri.TryCreate(url, UriKind.Absolute, out var uri)
+        && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)
+            ? url
+            : null;
+
     public async ValueTask<string> ResolveAssetUrlAsync(
         string url,
         CancellationToken cancellationToken = default

--- a/DiscordChatExporter.Core/Exporting/HtmlMarkdownVisitor.cs
+++ b/DiscordChatExporter.Core/Exporting/HtmlMarkdownVisitor.cs
@@ -188,12 +188,19 @@ internal partial class HtmlMarkdownVisitor(
             .Groups[1]
             .Value;
 
+        var safeUrl = ExportContext.EnsureSafeUrl(link.Url);
+        if (string.IsNullOrWhiteSpace(safeUrl))
+        {
+            await VisitAsync(link.Children, cancellationToken);
+            return;
+        }
+
         buffer.Append(
             !string.IsNullOrWhiteSpace(linkedMessageId)
                 // lang=html
-                ? $"""<a href="{HtmlEncode(link.Url)}" onclick="scrollToMessage(event, '{linkedMessageId}')">"""
+                ? $"""<a href="{HtmlEncode(safeUrl)}" onclick="scrollToMessage(event, '{linkedMessageId}')">"""
                 // lang=html
-                : $"""<a href="{HtmlEncode(link.Url)}">"""
+                : $"""<a href="{HtmlEncode(safeUrl)}">"""
         );
 
         await VisitAsync(link.Children, cancellationToken);

--- a/DiscordChatExporter.Core/Exporting/MessageGroupTemplate.cshtml
+++ b/DiscordChatExporter.Core/Exporting/MessageGroupTemplate.cshtml
@@ -24,6 +24,9 @@
     string FormatDate(DateTimeOffset instant, string format = "g") =>
         Context.FormatDate(instant, format);
 
+    string? EnsureSafeUrl(string? url) =>
+        ExportContext.EnsureSafeUrl(url);
+
     async ValueTask<IEncodedContent> FormatMarkdownAsync(string markdown) =>
         Context.Request.ShouldFormatMarkdown
             ? Html.Raw(await HtmlMarkdownVisitor.FormatAsync(Context, markdown, true, CancellationToken))
@@ -484,9 +487,10 @@
 
                                                     @if (!string.IsNullOrWhiteSpace(embed.Author.Name))
                                                     {
-                                                        if (!string.IsNullOrWhiteSpace(embed.Author.Url))
+                                                        var authorUrl = EnsureSafeUrl(embed.Author.Url);
+                                                        if (!string.IsNullOrWhiteSpace(authorUrl))
                                                         {
-                                                            <a class="chatlog__embed-author-link" href="@embed.Author.Url">
+                                                            <a class="chatlog__embed-author-link" href="@authorUrl">
                                                                 <div class="chatlog__embed-author">@embed.Author.Name</div>
                                                             </a>
                                                         }
@@ -502,9 +506,12 @@
                                             @if (!string.IsNullOrWhiteSpace(embed.Title))
                                             {
                                                 <div class="chatlog__embed-title">
-                                                    @if (!string.IsNullOrWhiteSpace(embed.Url))
+                                                    @{
+                                                        var titleUrl = EnsureSafeUrl(embed.Url);
+                                                    }
+                                                    @if (!string.IsNullOrWhiteSpace(titleUrl))
                                                     {
-                                                        <a class="chatlog__embed-title-link" href="@embed.Url">
+                                                        <a class="chatlog__embed-title-link" href="@titleUrl">
                                                             <div class="chatlog__markdown chatlog__markdown-preserve"><!--wmm:ignore-->@(await FormatEmbedMarkdownAsync(embed.Title))<!--/wmm:ignore--></div>
                                                         </a>
                                                     }
@@ -604,9 +611,10 @@
 
                                                     @if (!string.IsNullOrWhiteSpace(embed.Author.Name))
                                                     {
-                                                        if (!string.IsNullOrWhiteSpace(embed.Author.Url))
+                                                        var authorUrl = EnsureSafeUrl(embed.Author.Url);
+                                                        if (!string.IsNullOrWhiteSpace(authorUrl))
                                                         {
-                                                            <a class="chatlog__embed-author-link" href="@embed.Author.Url">
+                                                            <a class="chatlog__embed-author-link" href="@authorUrl">
                                                                 <div class="chatlog__embed-author">@embed.Author.Name</div>
                                                             </a>
                                                         }
@@ -622,9 +630,12 @@
                                             @if (!string.IsNullOrWhiteSpace(embed.Title))
                                             {
                                                 <div class="chatlog__embed-title">
-                                                    @if (!string.IsNullOrWhiteSpace(embed.Url))
+                                                    @{
+                                                        var titleUrl = EnsureSafeUrl(embed.Url);
+                                                    }
+                                                    @if (!string.IsNullOrWhiteSpace(titleUrl))
                                                     {
-                                                        <a class="chatlog__embed-title-link" href="@embed.Url">
+                                                        <a class="chatlog__embed-title-link" href="@titleUrl">
                                                             <div class="chatlog__markdown chatlog__markdown-preserve"><!--wmm:ignore-->@(await FormatEmbedMarkdownAsync(embed.Title))<!--/wmm:ignore--></div>
                                                         </a>
                                                     }


### PR DESCRIPTION
Fixes #1575.

`EnsureSafeUrl` on `ExportContext`, as you suggested, returning the URL only when it parses as an absolute http or https URI:

```csharp
public static string? EnsureSafeUrl(string? url) =>
    Uri.TryCreate(url, UriKind.Absolute, out var uri)
    && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)
        ? url
        : null;
```

Applied at the four embed anchors. Each already had an else branch rendering the title or author as a plain div, so an unsafe URL now takes that path and the text still shows, just unlinked.

`HtmlMarkdownVisitor.VisitLinkAsync` uses the same helper and renders the link children without an anchor when the scheme is not allowed. That way the three regexes in `MarkdownParser` are no longer the only thing keeping unsafe schemes out of the export, which is what let #1568 miss the embed path.

Verified against `prime` by serving the payload from a local stand-in for the Discord API:

- `javascript:` and `data:` in `embed.url` and `embed.author.url` produce no `href`, and the title and author text still render
- `https://example.com/page?a=1&b=2` and `http://example.org/author` still render as links

The `Cli.Tests` specs export live channels, so covering this in the suite needs a fixture channel carrying an embed with an author URL and a title URL. Point me at one and I'll add the specs.

Left the private-range question out, as discussed. It needs a `ConnectCallback` rather than a scheme check, so it does not belong in this change.
