### PR TITLE
Add official-web X-Super-Properties for user accounts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,8 +50,30 @@ jobs:
         if: ${{ failure() && steps.verify.outcome == 'failure' }}
         run: echo "::error title=Bad formatting::Formatting issues detected. Please build the solution locally to fix them."
 
+  test-unit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+
+      - name: Run token-free tests
+        run: >
+          dotnet test DiscordChatExporter.Cli.Tests
+          -p:CSharpier_Bypass=true
+          --configuration Release
+          --filter FullyQualifiedName~ClientPropertiesSpecs
+          --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
+
   test:
-    # Tests need access to secrets, so we can't run them against PRs because of limited trust
+    # Live export tests need access to secrets, so we can't run them against PRs
     if: ${{ github.event_name != 'pull_request' }}
 
     runs-on: ubuntu-latest
@@ -151,6 +173,7 @@ jobs:
     needs:
       - format
       - test
+      - test-unit
       - pack
 
     runs-on: ubuntu-latest

--- a/DiscordChatExporter.Cli.Tests/Specs/ClientPropertiesSpecs.cs
+++ b/DiscordChatExporter.Cli.Tests/Specs/ClientPropertiesSpecs.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Buffers.Binary;
+using System.Linq;
+using System.Text.Json;
+using DiscordChatExporter.Core.Discord;
+using FluentAssertions;
+using Xunit;
+
+namespace DiscordChatExporter.Cli.Tests.Specs;
+
+public class ClientPropertiesSpecs
+{
+    [Fact]
+    public void I_can_encode_official_web_super_properties_with_the_expected_shape()
+    {
+        // Arrange
+        const string launchId = "00000000-0000-4000-8000-000000000001";
+        const string launchSignature = "00000000-0000-4000-8000-000000000002";
+        const string heartbeatId = "00000000-0000-4000-8000-000000000003";
+
+        // Act
+        var encoded = DiscordClient.EncodeXSuperProperties(
+            DiscordClient.FallbackClientBuildNumber,
+            launchId,
+            launchSignature,
+            heartbeatId
+        );
+
+        using var doc = JsonDocument.Parse(Convert.FromBase64String(encoded));
+        var root = doc.RootElement;
+
+        // Assert
+        root.EnumerateObject()
+            .Select(p => p.Name)
+            .Should()
+            .Equal(
+                "os",
+                "browser",
+                "device",
+                "system_locale",
+                "has_client_mods",
+                "browser_user_agent",
+                "browser_version",
+                "os_version",
+                "referrer",
+                "referring_domain",
+                "referrer_current",
+                "referring_domain_current",
+                "release_channel",
+                "client_build_number",
+                "client_event_source",
+                "client_launch_id",
+                "launch_signature",
+                "client_heartbeat_session_id",
+                "client_app_state"
+            );
+
+        root.GetProperty("os").GetString().Should().Be("Windows");
+        root.GetProperty("browser").GetString().Should().Be("Chrome");
+        root.GetProperty("device").GetString().Should().BeEmpty();
+        root.GetProperty("system_locale").GetString().Should().Be("en-US");
+        root.GetProperty("has_client_mods").GetBoolean().Should().BeFalse();
+        root.GetProperty("browser_user_agent")
+            .GetString()
+            .Should()
+            .Be(DiscordClient.BrowserUserAgent);
+        root.GetProperty("browser_version").GetString().Should().Be("152.0.0.0");
+        root.GetProperty("os_version").GetString().Should().Be("10");
+        root.GetProperty("referrer").GetString().Should().BeEmpty();
+        root.GetProperty("referring_domain").GetString().Should().BeEmpty();
+        root.GetProperty("referrer_current").GetString().Should().BeEmpty();
+        root.GetProperty("referring_domain_current").GetString().Should().BeEmpty();
+        root.GetProperty("release_channel").GetString().Should().Be("stable");
+        root.GetProperty("client_build_number").ValueKind.Should().Be(JsonValueKind.Number);
+        root.GetProperty("client_build_number")
+            .GetInt32()
+            .Should()
+            .Be(DiscordClient.FallbackClientBuildNumber);
+        root.GetProperty("client_event_source").ValueKind.Should().Be(JsonValueKind.Null);
+        root.GetProperty("client_launch_id").GetString().Should().Be(launchId);
+        root.GetProperty("launch_signature").GetString().Should().Be(launchSignature);
+        root.GetProperty("client_heartbeat_session_id").GetString().Should().Be(heartbeatId);
+        root.GetProperty("client_app_state").GetString().Should().Be("unfocused");
+    }
+
+    [Fact]
+    public void User_agent_bytes_match_the_super_properties_browser_user_agent()
+    {
+        // Act
+        var encoded = DiscordClient.EncodeXSuperProperties(
+            DiscordClient.FallbackClientBuildNumber,
+            Guid.NewGuid().ToString(),
+            DiscordClient.GenerateLaunchSignature(),
+            Guid.NewGuid().ToString()
+        );
+
+        using var doc = JsonDocument.Parse(Convert.FromBase64String(encoded));
+
+        // Assert
+        doc.RootElement.GetProperty("browser_user_agent")
+            .GetString()
+            .Should()
+            .Be(DiscordClient.BrowserUserAgent);
+    }
+
+    [Fact]
+    public void Launch_signature_clears_client_mod_detection_bits()
+    {
+        // Act
+        var signatures = Enumerable
+            .Range(0, 32)
+            .Select(_ => DiscordClient.GenerateLaunchSignature())
+            .ToArray();
+
+        // Assert
+        Span<byte> bytes = stackalloc byte[16];
+        foreach (var signature in signatures)
+        {
+            var guid = Guid.Parse(signature);
+            guid.TryWriteBytes(bytes, bigEndian: true, out _);
+
+            var value = new UInt128(
+                BinaryPrimitives.ReadUInt64BigEndian(bytes),
+                BinaryPrimitives.ReadUInt64BigEndian(bytes[8..])
+            );
+
+            (value & DiscordClient.LaunchSignatureMask).Should().Be(UInt128.Zero);
+            guid.ToString().Should().Be(signature);
+        }
+    }
+
+    [Fact]
+    public void I_can_parse_the_client_build_number_from_discord_app_html()
+    {
+        // Arrange
+        const string html =
+            """<script>window.GLOBAL_ENV = {"NODE_ENV":"production","BUILD_NUMBER":"594503","RELEASE_CHANNEL":"stable"}</script>""";
+
+        // Act
+        var buildNumber = DiscordClient.TryParseClientBuildNumber(html);
+
+        // Assert
+        buildNumber.Should().Be(594503);
+        DiscordClient.TryParseClientBuildNumber("<html></html>").Should().BeNull();
+        DiscordClient.TryParseClientBuildNumber("\"BUILD_NUMBER\":\"abc\"").Should().BeNull();
+    }
+}

--- a/DiscordChatExporter.Core/Discord/DiscordClient.cs
+++ b/DiscordChatExporter.Core/Discord/DiscordClient.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Buffers;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -26,12 +28,27 @@ public class DiscordClient(
     private readonly Uri _baseUri = new("https://discord.com/api/v10/", UriKind.Absolute);
     private TokenKind? _resolvedTokenKind;
 
+    // Session-scoped IDs for official-web X-Super-Properties. Minted per DiscordClient
+    // so two tokens in one process do not share a launch fingerprint.
+    // https://docs.discord.food/reference#client-properties
+    private readonly string _clientLaunchId = Guid.NewGuid().ToString();
+    private readonly string _launchSignature = GenerateLaunchSignature();
+    private readonly string _clientHeartbeatSessionId = Guid.NewGuid().ToString();
+    private string? _xSuperPropertiesHeader;
+    private int _clientBuildNumberResolved;
+
     private async ValueTask<HttpResponseMessage> GetResponseAsync(
         string url,
         TokenKind tokenKind,
         CancellationToken cancellationToken = default
-    ) =>
-        await Http.ResponseResiliencePipeline.ExecuteAsync(
+    )
+    {
+        // Scrape outside the retry pipeline so a failed /app fetch cannot be
+        // retried as if it were a Discord API error.
+        if (tokenKind == TokenKind.User)
+            await RefreshClientBuildNumberAsync(cancellationToken);
+
+        return await Http.ResponseResiliencePipeline.ExecuteAsync(
             async innerCancellationToken =>
             {
                 using var request = new HttpRequestMessage(HttpMethod.Get, new Uri(_baseUri, url));
@@ -42,6 +59,9 @@ public class DiscordClient(
                     "Authorization",
                     tokenKind == TokenKind.Bot ? $"Bot {token}" : token
                 );
+
+                if (tokenKind == TokenKind.User)
+                    AddUserClientHeaders(request);
 
                 var response = await Http.Client.SendAsync(
                     request,
@@ -90,6 +110,92 @@ public class DiscordClient(
             },
             cancellationToken
         );
+    }
+
+    private void AddUserClientHeaders(HttpRequestMessage request)
+    {
+        // TryAddWithoutValidation keeps the User-Agent bytes identical to
+        // browser_user_agent. Typed UserAgent APIs re-serialize the value.
+        request.Headers.TryAddWithoutValidation("User-Agent", BrowserUserAgent);
+        request.Headers.TryAddWithoutValidation("X-Super-Properties", GetXSuperPropertiesHeader());
+        request.Headers.TryAddWithoutValidation("X-Discord-Locale", "en-US");
+        request.Headers.TryAddWithoutValidation("Accept-Language", "en-US");
+        request.Headers.TryAddWithoutValidation("X-Debug-Options", "bugReporterEnabled");
+
+        if (TryGetIanaTimeZone() is { } timeZone)
+            request.Headers.TryAddWithoutValidation("X-Discord-Timezone", timeZone);
+    }
+
+    private string GetXSuperPropertiesHeader() =>
+        _xSuperPropertiesHeader ??= EncodeXSuperProperties(
+            FallbackClientBuildNumber,
+            _clientLaunchId,
+            _launchSignature,
+            _clientHeartbeatSessionId
+        );
+
+    private async ValueTask RefreshClientBuildNumberAsync(CancellationToken cancellationToken)
+    {
+        if (Interlocked.CompareExchange(ref _clientBuildNumberResolved, 1, 0) != 0)
+            return;
+
+        var buildNumber = await TryScrapeClientBuildNumberAsync(cancellationToken);
+        if (buildNumber is null)
+            return;
+
+        _xSuperPropertiesHeader = EncodeXSuperProperties(
+            buildNumber.Value,
+            _clientLaunchId,
+            _launchSignature,
+            _clientHeartbeatSessionId
+        );
+    }
+
+    private static async ValueTask<int?> TryScrapeClientBuildNumberAsync(
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeout.CancelAfter(TimeSpan.FromSeconds(5));
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, "https://discord.com/app");
+            request.Headers.TryAddWithoutValidation("User-Agent", BrowserUserAgent);
+
+            using var response = await Http.Client.SendAsync(
+                request,
+                HttpCompletionOption.ResponseContentRead,
+                timeout.Token
+            );
+
+            if (!response.IsSuccessStatusCode)
+                return null;
+
+            var html = await response.Content.ReadAsStringAsync(cancellationToken);
+            return TryParseClientBuildNumber(html);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            // Keep the hardcoded build number. Never omit X-Super-Properties.
+            return null;
+        }
+    }
+
+    private static string? TryGetIanaTimeZone()
+    {
+        var timeZone = TimeZoneInfo.Local;
+        if (timeZone.HasIanaId)
+            return timeZone.Id;
+
+        return TimeZoneInfo.TryConvertWindowsIdToIanaId(timeZone.Id, out var ianaId)
+            ? ianaId
+            : null;
+    }
 
     private async ValueTask<TokenKind> ResolveTokenKindAsync(
         CancellationToken cancellationToken = default
@@ -875,5 +981,94 @@ public class DiscordClient(
             if (count <= 0)
                 yield break;
         }
+    }
+
+    // Official-web Chrome user agent. Must match X-Super-Properties.browser_user_agent.
+    internal const string BrowserUserAgent =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36";
+
+    internal const int FallbackClientBuildNumber = 594503;
+
+    // Client-mod detection bits (jQuery, BetterDiscord, Vencord, …).
+    // https://docs.discord.food/reference#launch-signature
+    internal static readonly UInt128 LaunchSignatureMask = new(
+        0x0080101008100800,
+        0x2081004001000800
+    );
+
+    internal static string GenerateLaunchSignature()
+    {
+        Span<byte> bytes = stackalloc byte[16];
+        Guid.NewGuid().TryWriteBytes(bytes, bigEndian: true, out _);
+
+        var value =
+            new UInt128(
+                BinaryPrimitives.ReadUInt64BigEndian(bytes),
+                BinaryPrimitives.ReadUInt64BigEndian(bytes[8..])
+            ) & ~LaunchSignatureMask;
+
+        BinaryPrimitives.WriteUInt64BigEndian(bytes, (ulong)(value >> 64));
+        BinaryPrimitives.WriteUInt64BigEndian(bytes[8..], (ulong)value);
+
+        return new Guid(bytes, bigEndian: true).ToString();
+    }
+
+    internal static string EncodeXSuperProperties(
+        int clientBuildNumber,
+        string clientLaunchId,
+        string launchSignature,
+        string clientHeartbeatSessionId
+    )
+    {
+        var buffer = new ArrayBufferWriter<byte>(512);
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("os", "Windows");
+            writer.WriteString("browser", "Chrome");
+            writer.WriteString("device", "");
+            writer.WriteString("system_locale", "en-US");
+            writer.WriteBoolean("has_client_mods", false);
+            writer.WriteString("browser_user_agent", BrowserUserAgent);
+            writer.WriteString("browser_version", "152.0.0.0");
+            writer.WriteString("os_version", "10");
+            writer.WriteString("referrer", "");
+            writer.WriteString("referring_domain", "");
+            writer.WriteString("referrer_current", "");
+            writer.WriteString("referring_domain_current", "");
+            writer.WriteString("release_channel", "stable");
+            writer.WriteNumber("client_build_number", clientBuildNumber);
+            writer.WriteNull("client_event_source");
+            writer.WriteString("client_launch_id", clientLaunchId);
+            writer.WriteString("launch_signature", launchSignature);
+            writer.WriteString("client_heartbeat_session_id", clientHeartbeatSessionId);
+            writer.WriteString("client_app_state", "unfocused");
+            writer.WriteEndObject();
+        }
+
+        return Convert.ToBase64String(buffer.WrittenSpan);
+    }
+
+    internal static int? TryParseClientBuildNumber(string html)
+    {
+        const string marker = "\"BUILD_NUMBER\":\"";
+        var start = html.IndexOf(marker, StringComparison.Ordinal);
+        if (start < 0)
+            return null;
+
+        start += marker.Length;
+        var end = html.IndexOf('"', start);
+        if (end < 0)
+            return null;
+
+        return
+            int.TryParse(
+                html.AsSpan(start, end - start),
+                CultureInfo.InvariantCulture,
+                out var buildNumber
+            )
+            && buildNumber > 0
+            ? buildNumber
+            : null;
     }
 }

--- a/DiscordChatExporter.Core/DiscordChatExporter.Core.csproj
+++ b/DiscordChatExporter.Core/DiscordChatExporter.Core.csproj
@@ -1,5 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <InternalsVisibleTo Include="DiscordChatExporter.Cli.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="AngleSharp" />
     <PackageReference Include="AsyncKeyedLock" />
     <PackageReference Include="CSharpier.MsBuild" PrivateAssets="all" />


### PR DESCRIPTION
User-token GETs currently send only `Authorization`. Official web clients also send `X-Super-Properties` (and a matching `User-Agent`); Discord uses those for anti-abuse. This PR generates a complete Windows/Chrome **web** fingerprint locally and attaches it on every `TokenKind.User` request, including the first `users/@me` probe.

Bot tokens are unchanged. `_baseUri` stays on `/api/v10`.

Related: #1497

Does **not** close #1497: `X-Super-Properties` (and a matching `User-Agent`) only stop user-token GETs from looking headerless. They are not a ban fix. Stock DCE and both earlier XSP PRs (#1507 / #1510) still produced password resets, 24h disables, and standing hits after completed exports, especially on high-volume / many-thread runs.

## What this sends (user tokens only)

- `User-Agent` = `X-Super-Properties.browser_user_agent` (Chrome 152 on Windows, exact bytes via `TryAddWithoutValidation`)
- 19-key official-web `X-Super-Properties` (compact JSON, `client_build_number` as a number, `client_event_source: null`)
- `X-Discord-Locale` / `Accept-Language`: `en-US`
- `X-Discord-Timezone`: host IANA zone, or omitted
- `X-Debug-Options`: `bugReporterEnabled`

Omitted on purpose: `X-Context-Properties` (official web does not send it on message/`@me`/thread-search GETs; a hardcoded `/app` blob is a tell), cookies, `sec-ch-ua*`, Origin/Referer, TLS impersonation.

Headers are added on the request, not on the shared `Http.Client` used by the asset downloader.

## How it is generated

- Local encode. No third-party props API.
- Windows + Chrome web, regardless of host OS (Linux XSP is the sensitive profile).
- `client_build_number` defaults to `594503` (current stable `GLOBAL_ENV`). Optional one-shot scrape of `https://discord.com/app` (5s timeout); scrape failure still sends the hardcoded complete object.
- `client_launch_id` / `launch_signature` / `client_heartbeat_session_id` minted once per `DiscordClient` instance (not process-static).
- `launch_signature` uses the RFC-4122 big-endian UInt128 mask from [discord.food](https://docs.discord.food/reference#launch-signature). This is not the `BitArray` + `Guid.ToByteArray()` approach from #1510, which clears the wrong bits.

A user-token request is never `Authorization`-only and never UA-without-XSP after this change.

## Tests / CI

Token-free specs cover JSON shape and types, UA coupling, launch-signature bits, and `BUILD_NUMBER` parsing. A new `test-unit` job runs those on PRs. Live export tests stay skip-on-PR (secrets).

## Credit

Builds on #1507 (wavedevgit) and #1510 (AlmightyLks), and on dolfies' client-properties work. This revision is the locally generated, complete web object they converged on, without a required third-party API.