### PR TITLE
Preserve machine-readable metadata in HTML exports

### DIFF
--- a/DiscordChatExporter.Cli.Tests/Specs/HtmlContentSpecs.cs
+++ b/DiscordChatExporter.Cli.Tests/Specs/HtmlContentSpecs.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -19,9 +21,18 @@ public class HtmlContentSpecs
     public async Task I_can_export_a_channel_in_the_HTML_format()
     {
         // Act
-        var messages = await ExportWrapper.GetMessagesAsHtmlAsync(ChannelIds.DateRangeTestCases);
+        var document = await ExportWrapper.ExportAsHtmlAsync(ChannelIds.DateRangeTestCases);
+        var chatlog = document.QuerySelector(".chatlog");
+        var messages = document.QuerySelectorAll("[data-message-id]").ToArray();
 
         // Assert
+        chatlog.Should().NotBeNull();
+        chatlog!.GetAttribute("data-machine-metadata-version").Should().Be("1");
+        chatlog
+            .GetAttribute("data-channel-id")
+            .Should()
+            .Be(ChannelIds.DateRangeTestCases.ToString());
+
         messages
             .Select(e => e.GetAttribute("data-message-id"))
             .Should()
@@ -49,6 +60,58 @@ public class HtmlContentSpecs
                 "Three",
                 "Yeet"
             );
+
+        foreach (var message in messages)
+        {
+            message.GetAttribute("data-message-type").Should().NotBeNullOrWhiteSpace();
+            message.GetAttribute("data-author-id").Should().NotBeNullOrWhiteSpace();
+            message.GetAttribute("data-author-name").Should().NotBeNullOrWhiteSpace();
+            message.GetAttribute("data-author-display-name").Should().NotBeNullOrWhiteSpace();
+
+            DateTimeOffset
+                .TryParseExact(
+                    message.GetAttribute("data-timestamp"),
+                    "O",
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.RoundtripKind,
+                    out _
+                )
+                .Should()
+                .BeTrue();
+        }
+    }
+
+    [Fact]
+    public async Task I_can_disable_machine_metadata_in_the_HTML_format()
+    {
+        // Arrange
+        using var file = TempFile.Create();
+
+        // Act
+        await new ExportChannelsCommand
+        {
+            Token = Secrets.DiscordToken,
+            ChannelIds = [ChannelIds.DateRangeTestCases],
+            ExportFormat = ExportFormat.HtmlDark,
+            OutputPath = file.Path,
+            Locale = "en-US",
+            IsUtcNormalizationEnabled = true,
+            ShouldIncludeMachineMetadata = false,
+        }.ExecuteAsync(new FakeConsole());
+
+        var document = Html.Parse(await File.ReadAllTextAsync(file.Path));
+        var chatlog = document.QuerySelector(".chatlog");
+        var messages = document.QuerySelectorAll("[data-message-id]");
+
+        // Assert
+        chatlog.Should().NotBeNull();
+        chatlog!.HasAttribute("data-machine-metadata-version").Should().BeFalse();
+
+        foreach (var message in messages)
+        {
+            message.HasAttribute("data-author-id").Should().BeFalse();
+            message.HasAttribute("data-timestamp").Should().BeFalse();
+        }
     }
 
     [Fact]

--- a/DiscordChatExporter.Cli.Tests/Specs/HtmlGroupingSpecs.cs
+++ b/DiscordChatExporter.Cli.Tests/Specs/HtmlGroupingSpecs.cs
@@ -38,6 +38,16 @@ public class HtmlGroupingSpecs
 
         messageGroups.Should().HaveCount(2);
 
+        foreach (
+            var message in messageGroups.SelectMany(group =>
+                group.QuerySelectorAll(".chatlog__message-container")
+            )
+        )
+        {
+            message.GetAttribute("data-author-id").Should().NotBeNullOrWhiteSpace();
+            message.GetAttribute("data-timestamp").Should().NotBeNullOrWhiteSpace();
+        }
+
         messageGroups[0]
             .QuerySelectorAll(".chatlog__content")
             .Select(e => e.Text())

--- a/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
+++ b/DiscordChatExporter.Cli/Commands/Base/ExportCommandBase.cs
@@ -96,6 +96,12 @@ public abstract class ExportCommandBase : DiscordCommandBase
     public bool ShouldFormatMarkdown { get; set; } = true;
 
     [CommandOption(
+        "machine-metadata",
+        Description = "Include machine-readable metadata in HTML exports (enabled by default)."
+    )]
+    public bool ShouldIncludeMachineMetadata { get; set; } = true;
+
+    [CommandOption(
         "media",
         Description = "Download assets referenced by the export (user avatars, attached files, embedded images, etc.)."
     )]
@@ -286,7 +292,8 @@ public abstract class ExportCommandBase : DiscordCommandBase
                                         ShouldDownloadAssets,
                                         ShouldReuseAssets,
                                         Locale,
-                                        IsUtcNormalizationEnabled
+                                        IsUtcNormalizationEnabled,
+                                        ShouldIncludeMachineMetadata
                                     );
 
                                     await Exporter.ExportChannelAsync(

--- a/DiscordChatExporter.Core/Exporting/ExportRequest.cs
+++ b/DiscordChatExporter.Core/Exporting/ExportRequest.cs
@@ -37,6 +37,8 @@ public partial class ExportRequest
 
     public bool ShouldFormatMarkdown { get; }
 
+    public bool ShouldIncludeMachineMetadata { get; }
+
     public bool ShouldDownloadAssets { get; }
 
     public bool ShouldReuseAssets { get; }
@@ -62,7 +64,8 @@ public partial class ExportRequest
         bool shouldDownloadAssets,
         bool shouldReuseAssets,
         string? locale,
-        bool isUtcNormalizationEnabled
+        bool isUtcNormalizationEnabled,
+        bool shouldIncludeMachineMetadata = true
     )
     {
         Guild = guild;
@@ -74,6 +77,7 @@ public partial class ExportRequest
         MessageFilter = messageFilter;
         IsReverseMessageOrder = isReverseMessageOrder;
         ShouldFormatMarkdown = shouldFormatMarkdown;
+        ShouldIncludeMachineMetadata = shouldIncludeMachineMetadata;
         ShouldDownloadAssets = shouldDownloadAssets;
         ShouldReuseAssets = shouldReuseAssets;
         Locale = locale;

--- a/DiscordChatExporter.Core/Exporting/HtmlMessageWriter.cs
+++ b/DiscordChatExporter.Core/Exporting/HtmlMessageWriter.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using DiscordChatExporter.Core.Discord.Data;
@@ -16,6 +18,106 @@ internal class HtmlMessageWriter(Stream stream, ExportContext context, string th
 
     private readonly HtmlMinifier _minifier = new();
     private readonly List<Message> _messageGroup = [];
+
+    private static string FormatMetadataAttribute(string name, object? value)
+    {
+        if (value is null)
+            return "";
+
+        var stringValue =
+            value switch
+            {
+                bool boolean => boolean ? "true" : "false",
+                IFormattable formattable => formattable.ToString(
+                    null,
+                    CultureInfo.InvariantCulture
+                ),
+                _ => value.ToString(),
+            } ?? "";
+
+        return $" {name}=\"{WebUtility.HtmlEncode(stringValue)}\"";
+    }
+
+    private static string FormatMetadataAttributes(
+        params (string Name, object? Value)[] attributes
+    ) =>
+        string.Concat(
+            attributes.Select(attribute => FormatMetadataAttribute(attribute.Name, attribute.Value))
+        );
+
+    private string FormatMachineTimestamp(DateTimeOffset timestamp) =>
+        Context.NormalizeDate(timestamp).ToString("O", CultureInfo.InvariantCulture);
+
+    private string AddExportMetadata(string html)
+    {
+        if (!Context.Request.ShouldIncludeMachineMetadata)
+            return html;
+
+        const string marker = "<div class=\"chatlog\">";
+        var replacement =
+            "<div class=\"chatlog\""
+            + FormatMetadataAttributes(
+                ("data-machine-metadata-version", 1),
+                ("data-guild-id", Context.Request.Guild.IsDirect ? null : Context.Request.Guild.Id),
+                ("data-channel-id", Context.Request.Channel.Id),
+                ("data-channel-type", Context.Request.Channel.Kind),
+                ("data-parent-channel-id", Context.Request.Channel.Parent?.Id)
+            )
+            + ">";
+
+        return html.Replace(marker, replacement, StringComparison.Ordinal);
+    }
+
+    private string AddMessageMetadata(string html, IReadOnlyList<Message> messages)
+    {
+        if (!Context.Request.ShouldIncludeMachineMetadata)
+            return html;
+
+        foreach (var message in messages)
+        {
+            var authorMember = Context.TryGetMember(message.Author.Id);
+            var authorDisplayName = message.Author.IsBot
+                ? message.Author.DisplayName
+                : authorMember?.DisplayName ?? message.Author.DisplayName;
+
+            var marker = $"data-message-id=\"{message.Id}\"";
+            var replacement =
+                marker
+                + FormatMetadataAttributes(
+                    ("data-message-type", message.Kind),
+                    ("data-author-id", message.Author.Id),
+                    ("data-author-name", message.Author.Name),
+                    ("data-author-display-name", authorDisplayName),
+                    ("data-author-is-bot", message.Author.IsBot),
+                    ("data-timestamp", FormatMachineTimestamp(message.Timestamp)),
+                    (
+                        "data-edited-timestamp",
+                        message.EditedTimestamp is { } editedTimestamp
+                            ? FormatMachineTimestamp(editedTimestamp)
+                            : null
+                    ),
+                    (
+                        "data-call-ended-timestamp",
+                        message.CallEndedTimestamp is { } callEndedTimestamp
+                            ? FormatMachineTimestamp(callEndedTimestamp)
+                            : null
+                    ),
+                    ("data-is-pinned", message.IsPinned),
+                    ("data-is-forwarded", message.IsForwarded),
+                    ("data-reference-type", message.Reference?.Kind),
+                    ("data-reference-message-id", message.Reference?.MessageId),
+                    ("data-reference-channel-id", message.Reference?.ChannelId),
+                    ("data-reference-guild-id", message.Reference?.GuildId),
+                    ("data-interaction-id", message.Interaction?.Id),
+                    ("data-interaction-name", message.Interaction?.Name),
+                    ("data-interaction-user-id", message.Interaction?.User.Id)
+                );
+
+            html = html.Replace(marker, replacement, StringComparison.Ordinal);
+        }
+
+        return html;
+    }
 
     // Note: in reverse order, last message appears earlier than the first message
     private bool CanJoinGroup(Message message)
@@ -72,13 +174,13 @@ internal class HtmlMessageWriter(Stream stream, ExportContext context, string th
         CancellationToken cancellationToken = default
     )
     {
-        await _writer.WriteLineAsync(
-            Minify(
-                await new PreambleTemplate { Context = Context, ThemeName = themeName }.RenderAsync(
-                    cancellationToken
-                )
-            )
-        );
+        var html = await new PreambleTemplate
+        {
+            Context = Context,
+            ThemeName = themeName,
+        }.RenderAsync(cancellationToken);
+
+        await _writer.WriteLineAsync(Minify(AddExportMetadata(html)));
     }
 
     private async ValueTask WriteMessageGroupAsync(
@@ -86,15 +188,13 @@ internal class HtmlMessageWriter(Stream stream, ExportContext context, string th
         CancellationToken cancellationToken = default
     )
     {
-        await _writer.WriteLineAsync(
-            Minify(
-                await new MessageGroupTemplate
-                {
-                    Context = Context,
-                    Messages = messages,
-                }.RenderAsync(cancellationToken)
-            )
-        );
+        var html = await new MessageGroupTemplate
+        {
+            Context = Context,
+            Messages = messages,
+        }.RenderAsync(cancellationToken);
+
+        await _writer.WriteLineAsync(Minify(AddMessageMetadata(html, messages)));
     }
 
     public override async ValueTask WriteMessageAsync(

--- a/DiscordChatExporter.Gui/Localization/LocalizationManager.English.cs
+++ b/DiscordChatExporter.Gui/Localization/LocalizationManager.English.cs
@@ -112,6 +112,9 @@ public partial class LocalizationManager
             [nameof(FormatMarkdownLabel)] = "Format markdown",
             [nameof(FormatMarkdownTooltip)] =
                 "Process markdown, mentions, and other special tokens",
+            [nameof(MachineMetadataLabel)] = "Include machine-readable metadata",
+            [nameof(MachineMetadataTooltip)] =
+                "Preserve stable identifiers, exact timestamps, and message relationships in HTML attributes. Disable this to reduce HTML file size.",
             [nameof(DownloadAssetsLabel)] = "Download assets",
             [nameof(DownloadAssetsTooltip)] =
                 "Download assets referenced by the export (user avatars, attached files, embedded images, etc.)",

--- a/DiscordChatExporter.Gui/Localization/LocalizationManager.cs
+++ b/DiscordChatExporter.Gui/Localization/LocalizationManager.cs
@@ -132,6 +132,8 @@ public partial class LocalizationManager
     public string ReverseMessageOrderTooltip => Get();
     public string FormatMarkdownLabel => Get();
     public string FormatMarkdownTooltip => Get();
+    public string MachineMetadataLabel => Get();
+    public string MachineMetadataTooltip => Get();
     public string DownloadAssetsLabel => Get();
     public string DownloadAssetsTooltip => Get();
     public string ReuseAssetsLabel => Get();

--- a/DiscordChatExporter.Gui/Services/SettingsService.cs
+++ b/DiscordChatExporter.Gui/Services/SettingsService.cs
@@ -64,6 +64,9 @@ public partial class SettingsService()
     public partial bool LastShouldFormatMarkdown { get; set; } = true;
 
     [ObservableProperty]
+    public partial bool LastShouldIncludeMachineMetadata { get; set; } = true;
+
+    [ObservableProperty]
     public partial bool LastShouldDownloadAssets { get; set; }
 
     [ObservableProperty]

--- a/DiscordChatExporter.Gui/ViewModels/Components/DashboardViewModel.cs
+++ b/DiscordChatExporter.Gui/ViewModels/Components/DashboardViewModel.cs
@@ -276,7 +276,8 @@ public partial class DashboardViewModel : ViewModelBase
                             dialog.ShouldDownloadAssets,
                             dialog.ShouldReuseAssets,
                             _settingsService.Locale,
-                            _settingsService.IsUtcNormalizationEnabled
+                            _settingsService.IsUtcNormalizationEnabled,
+                            dialog.ShouldIncludeMachineMetadata
                         );
 
                         await exporter.ExportChannelAsync(request, progress, cancellationToken);

--- a/DiscordChatExporter.Gui/ViewModels/Dialogs/ExportSetupViewModel.cs
+++ b/DiscordChatExporter.Gui/ViewModels/Dialogs/ExportSetupViewModel.cs
@@ -36,6 +36,7 @@ public partial class ExportSetupViewModel(
     public partial string? OutputPath { get; set; }
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsMachineMetadataAvailable))]
     public partial ExportFormat SelectedFormat { get; set; }
 
     [ObservableProperty]
@@ -69,6 +70,9 @@ public partial class ExportSetupViewModel(
     public partial bool ShouldFormatMarkdown { get; set; }
 
     [ObservableProperty]
+    public partial bool ShouldIncludeMachineMetadata { get; set; }
+
+    [ObservableProperty]
     public partial bool ShouldDownloadAssets { get; set; }
 
     [ObservableProperty]
@@ -81,6 +85,9 @@ public partial class ExportSetupViewModel(
     public partial bool IsAdvancedSectionDisplayed { get; set; }
 
     public bool IsSingleChannel => Channels?.Count == 1;
+
+    public bool IsMachineMetadataAvailable =>
+        SelectedFormat is ExportFormat.HtmlDark or ExportFormat.HtmlLight;
 
     public IReadOnlyList<ExportFormat> AvailableFormats { get; } = Enum.GetValues<ExportFormat>();
 
@@ -110,6 +117,7 @@ public partial class ExportSetupViewModel(
         MessageFilterValue = settingsService.LastMessageFilterValue;
         IsReverseMessageOrder = settingsService.LastIsReverseMessageOrder;
         ShouldFormatMarkdown = settingsService.LastShouldFormatMarkdown;
+        ShouldIncludeMachineMetadata = settingsService.LastShouldIncludeMachineMetadata;
         ShouldDownloadAssets = settingsService.LastShouldDownloadAssets;
         ShouldReuseAssets = settingsService.LastShouldReuseAssets;
         AssetsDirPath = settingsService.LastAssetsDirPath;
@@ -124,7 +132,8 @@ public partial class ExportSetupViewModel(
             || ShouldDownloadAssets
             || ShouldReuseAssets
             || !string.IsNullOrWhiteSpace(AssetsDirPath)
-            || IsReverseMessageOrder;
+            || IsReverseMessageOrder
+            || !ShouldIncludeMachineMetadata;
 
         return Task.CompletedTask;
     }
@@ -192,6 +201,7 @@ public partial class ExportSetupViewModel(
         settingsService.LastMessageFilterValue = MessageFilterValue;
         settingsService.LastIsReverseMessageOrder = IsReverseMessageOrder;
         settingsService.LastShouldFormatMarkdown = ShouldFormatMarkdown;
+        settingsService.LastShouldIncludeMachineMetadata = ShouldIncludeMachineMetadata;
         settingsService.LastShouldDownloadAssets = ShouldDownloadAssets;
         settingsService.LastShouldReuseAssets = ShouldReuseAssets;
         settingsService.LastAssetsDirPath = AssetsDirPath;

--- a/DiscordChatExporter.Gui/Views/Dialogs/ExportSetupView.axaml
+++ b/DiscordChatExporter.Gui/Views/Dialogs/ExportSetupView.axaml
@@ -220,6 +220,22 @@
               <ToggleSwitch DockPanel.Dock="Right" IsChecked="{Binding ShouldFormatMarkdown}" />
             </DockPanel>
 
+            <!--  Machine-readable metadata  -->
+            <DockPanel
+              IsVisible="{Binding IsMachineMetadataAvailable}"
+              LastChildFill="False"
+              ToolTip.Tip="{Binding LocalizationManager.MachineMetadataTooltip}"
+            >
+              <TextBlock
+                DockPanel.Dock="Left"
+                Text="{Binding LocalizationManager.MachineMetadataLabel}"
+              />
+              <ToggleSwitch
+                DockPanel.Dock="Right"
+                IsChecked="{Binding ShouldIncludeMachineMetadata}"
+              />
+            </DockPanel>
+
             <!--  Download assets  -->
             <DockPanel
               LastChildFill="False"


### PR DESCRIPTION
Closes #1585

## Summary

Preserves stable machine-readable metadata in HTML exports without changing
their visible presentation.

HTML currently groups consecutive messages for display, so an individual
continuation-message element is not independently attributable without
examining its preceding group header. Exact timestamps and several other
stable message properties already available during export are also omitted
from the HTML DOM.

This change makes individual message elements self-contained when machine
metadata is enabled.

## Configuration

Machine metadata is optional but enabled by default:

- CLI: `--machine-metadata true|false`
- GUI: **Include machine-readable metadata**

The GUI setting is displayed only when an HTML output format is selected and
is persisted with the other export preferences.

The default is enabled because omitted identifiers and relationships generally
cannot be reconstructed after export. Users who prioritize smaller
presentation-oriented HTML files can explicitly disable it.

## Included metadata

At export level:

- machine-metadata schema version;
- guild ID when applicable;
- channel ID and kind;
- parent-channel ID when applicable.

On every message container, including visually grouped continuation messages:

- message kind;
- author ID, username, display name, and bot state;
- exact normalized timestamp;
- optional edit and call-end timestamps;
- pinned and forwarded state;
- reference type and message, channel, and guild IDs;
- interaction ID, name, and user ID.

Optional values are omitted rather than serialized as empty attributes.

## Compatibility

- No visible HTML rendering changes.
- No additional Discord API requests.
- Existing HTML classes, anchors, and navigation behavior remain unchanged.
- Existing `data-message-id` output remains unconditional because the HTML
  viewer itself depends on it.
- Existing `ExportRequest` callers receive the new default-enabled behavior.
- Passing `--machine-metadata false`, or disabling the GUI setting, omits the
  newly introduced attributes.
- This does not replace JSON as the richer structured interchange format or
  attempt complete JSON/HTML parity.

## Validation

Validated against upstream `prime` commit
`905489b01b5523719082275c34c232fc47f827c6`:

```text
dotnet build -p:CSharpier_Bypass=true --configuration Release
dotnet build -t:CSharpierFormat --configuration Release --no-restore
```

The complete solution, including Core, CLI, GUI, and the CLI test project,
builds with zero warnings and zero errors.

Functional HTML specifications cover:

- metadata being enabled by default;
- metadata being explicitly disabled;
- exact timestamps being round-trip parseable;
- every visually grouped message retaining independent author and timestamp
  metadata.

Executing the credential-dependent functional tests themselves requires the
repository's Discord test credentials.

## Prior context

The `data-*` approach was discussed in #741. Preserving canonical information
in HTML attributes also has precedent in #1414.